### PR TITLE
Porting to Devart

### DIFF
--- a/Rebus.Oracle.Devart/Config/OracleConfigurationExtensions.cs
+++ b/Rebus.Oracle.Devart/Config/OracleConfigurationExtensions.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Devart.Data.Oracle;
+using Rebus.Auditing.Sagas;
+using Rebus.Logging;
+using Rebus.Oracle;
+using Rebus.Oracle.Sagas;
+using Rebus.Oracle.Subscriptions;
+using Rebus.Oracle.Timeouts;
+using Rebus.Sagas;
+using Rebus.Subscriptions;
+using Rebus.Timeouts;
+
+namespace Rebus.Config
+{
+    /// <summary>
+    /// Configuration extensions for Oracle persistence
+    /// </summary>
+    public static class OracleConfigurationExtensions
+    {
+        /// <summary>
+        /// Configures Rebus to use Oracle to store saga data snapshots, using the specified table to store the data
+        /// </summary>
+        public static void StoreInOracle(this StandardConfigurer<ISagaSnapshotStorage> configurer,
+            string connectionString, string tableName, bool automaticallyCreateTables = true, 
+            Action<OracleConnection> additionalConnectionSetup = null)
+        {
+            configurer.Register(c =>
+            {
+                var sagaStorage = new OracleSagaSnapshotStorage(new OracleConnectionHelper(connectionString, additionalConnectionSetup), tableName);
+
+                if (automaticallyCreateTables)
+                {
+                    sagaStorage.EnsureTableIsCreated();
+                }
+
+                return sagaStorage;
+            });
+        }
+
+        /// <summary>
+        /// Configures Rebus to use Oracle to store sagas, using the tables specified to store data and indexed properties respectively.
+        /// </summary>
+        public static void StoreInOracle(this StandardConfigurer<ISagaStorage> configurer,
+            string connectionString, string dataTableName, string indexTableName,
+            bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null)
+        {
+            configurer.Register(c =>
+            {
+                var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
+                var sagaStorage = new OracleSqlSagaStorage(new OracleConnectionHelper(connectionString, additionalConnectionSetup), dataTableName, indexTableName, rebusLoggerFactory);
+
+                if (automaticallyCreateTables)
+                {
+                    sagaStorage.EnsureTablesAreCreated();
+                }
+
+                return sagaStorage;
+            });
+        }
+
+        /// <summary>
+        /// Configures Rebus to use Oracle to store timeouts.
+        /// </summary>
+        public static void StoreInOracle(this StandardConfigurer<ITimeoutManager> configurer, string connectionString, string tableName, 
+            bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null)
+        {
+            configurer.Register(c =>
+            {
+                var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
+                var subscriptionStorage = new OracleTimeoutManager(new OracleConnectionHelper(connectionString, additionalConnectionSetup), tableName, rebusLoggerFactory);
+
+                if (automaticallyCreateTables)
+                {
+                    subscriptionStorage.EnsureTableIsCreated();
+                }
+
+                return subscriptionStorage;
+            });
+        }
+
+        /// <summary>
+        /// Configures Rebus to use Oracle to store subscriptions. Use <paramref name="isCentralized"/> = true to indicate whether it's OK to short-circuit
+        /// subscribing and unsubscribing by manipulating the subscription directly from the subscriber or just let it default to false to preserve the
+        /// default behavior.
+        /// </summary>
+        public static void StoreInOracle(this StandardConfigurer<ISubscriptionStorage> configurer,
+            string connectionString, string tableName, bool isCentralized = false, bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null)
+        {
+            configurer.Register(c =>
+            {
+                var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
+                var connectionHelper = new OracleConnectionHelper(connectionString, additionalConnectionSetup);
+                var subscriptionStorage = new OracleSubscriptionStorage(
+                    connectionHelper, tableName, isCentralized, rebusLoggerFactory);
+
+                if (automaticallyCreateTables)
+                {
+                    subscriptionStorage.EnsureTableIsCreated();
+                }
+
+                return subscriptionStorage;
+            });
+        }
+
+    }
+}

--- a/Rebus.Oracle.Devart/Config/OracleTransportConfigurationExtensions.cs
+++ b/Rebus.Oracle.Devart/Config/OracleTransportConfigurationExtensions.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Rebus.Logging;
+using Rebus.Oracle;
+using Rebus.Oracle.Transport;
+using Rebus.Pipeline;
+using Rebus.Pipeline.Receive;
+using Rebus.Threading;
+using Rebus.Timeouts;
+using Rebus.Transport;
+
+namespace Rebus.Config
+{
+    /// <summary>
+    /// Configuration extensions for the SQL transport
+    /// </summary>
+    public static class OracleTransportConfigurationExtensions
+    {
+        /// <summary>
+        /// Configures Rebus to use Oracle as its transport. The table specified by <paramref name="tableName"/> will be used to
+        /// store messages, and the "queue" specified by <paramref name="inputQueueName"/> will be used when querying for messages.
+        /// The message table will automatically be created if it does not exist.
+        /// </summary>
+        public static void UseOracle(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionOrConnectionStringName, string tableName, string inputQueueName)
+        {
+            Configure(configurer, loggerFactory => new OracleConnectionHelper(connectionStringOrConnectionOrConnectionStringName), tableName, inputQueueName);
+        }
+
+        /// <summary>
+        /// Configures Rebus to use Oracle to transport messages as a one-way client (i.e. will not be able to receive any messages).
+        /// The table specified by <paramref name="tableName"/> will be used to store messages.
+        /// The message table will automatically be created if it does not exist.
+        /// </summary>
+        public static void UseOracleAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionStringName, string tableName)
+        {
+            Configure(configurer, loggerFactory => new OracleConnectionHelper(connectionStringOrConnectionStringName), tableName, null);
+
+            OneWayClientBackdoor.ConfigureOneWayClient(configurer);
+        }
+
+        static void Configure(StandardConfigurer<ITransport> configurer, Func<IRebusLoggerFactory, OracleConnectionHelper> connectionProviderFactory, string tableName, string inputQueueName)
+        {
+            configurer.Register(context =>
+            {
+                var rebusLoggerFactory = context.Get<IRebusLoggerFactory>();
+                var asyncTaskFactory = context.Get<IAsyncTaskFactory>();
+                var connectionProvider = connectionProviderFactory(rebusLoggerFactory);
+                var transport = new OracleTransport(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory);
+                transport.EnsureTableIsCreated();
+                return transport;
+            });
+
+            configurer.OtherService<ITimeoutManager>().Register(c => new DisabledTimeoutManager());
+
+            configurer.OtherService<IPipeline>().Decorate(c =>
+            {
+                var pipeline = c.Get<IPipeline>();
+
+                return new PipelineStepRemover(pipeline)
+                    .RemoveIncomingStep(s => s.GetType() == typeof(HandleDeferredMessagesStep));
+            });
+        }
+    }
+}

--- a/Rebus.Oracle.Devart/Internals/SynchronizationContextRemover.cs
+++ b/Rebus.Oracle.Devart/Internals/SynchronizationContextRemover.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rebus.Internals
+{
+
+    /// <summary>
+    /// Used to remove context within an asynchronous method. All further async calls
+    /// after awaiting this class will be performed without a synchronization context. 
+    /// this avoids the need to call ConfigureAwait(false), all the way down the call
+    /// stack. Instead, doing await new SynchronizationContextRemover() at an api entry 
+    /// point should suffice. Previous synchronization context will be restored upon return
+    /// from the method that uses this.
+    /// 
+    /// </summary>
+    public class SynchronizationContextRemover : INotifyCompletion
+    {
+        /// <summary>
+        /// Implementation of IsCompleted for awaitable pattern
+        /// If current sync context is already null no need to run OnCompleted....
+        /// </summary>
+        public bool IsCompleted => SynchronizationContext.Current == null;
+
+        /// <summary>
+        /// 
+        /// Implemetnation of OnCompleted for awaitable pattern
+        /// Will run all continuations with no synchronization context.
+        /// After the continuation chain has finished executing it will restore
+        /// the previous context
+        /// </summary>
+        /// <param name="continuation"></param>
+        public void OnCompleted(Action continuation)
+        {
+            var previousContext = SynchronizationContext.Current;
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(null);
+                continuation();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(previousContext);
+            }
+        }
+
+        /// <summary>
+        /// GetAwaiter() awaitable pattern 
+        /// </summary>
+        /// <returns></returns>
+        public SynchronizationContextRemover GetAwaiter()
+        {
+            return this;
+        }
+
+        /// <summary>
+        /// GetResult for awaitable pattern 
+        /// </summary>
+        public void GetResult()
+        {
+        }
+    }
+}

--- a/Rebus.Oracle.Devart/Oracle/Magic.cs
+++ b/Rebus.Oracle.Devart/Oracle/Magic.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+
+namespace Rebus.Oracle
+{
+    static class OracleMagic
+    {
+        public static List<string> GetTableNames(this OracleDbConnection connection)
+        {
+            var tableNames = new List<string>();
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "select table_name from USER_TABLES";
+
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        tableNames.Add(reader["table_name"].ToString());
+                    }
+                }
+            }
+
+            return tableNames;
+        }
+    }
+}

--- a/Rebus.Oracle.Devart/Oracle/OracleConnectionHelper.cs
+++ b/Rebus.Oracle.Devart/Oracle/OracleConnectionHelper.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Data;
+using System.Threading.Tasks;
+using Devart.Data.Oracle;
+
+namespace Rebus.Oracle
+{
+    /// <summary>
+    /// Helps with managing <see cref="OracleConnection"/>s
+    /// </summary>
+    public class OracleConnectionHelper
+    {
+        readonly string _connectionString;
+        private readonly Action<OracleConnection> _additionalConnectionSetupCallback;
+
+        /// <summary>
+        /// Constructs this thingie
+        /// </summary>
+        public OracleConnectionHelper(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        /// <summary>
+        /// Constructs this thingie
+        /// </summary>
+        /// <param name="connectionString">Connection string.</param>
+        /// <param name="additionalConnectionSetupCallback">Additional setup to be performed prior to opening each connection. 
+        /// Useful for configuring client certificate authentication, as well as set up other callbacks.</param>
+        public OracleConnectionHelper(string connectionString, Action<OracleConnection> additionalConnectionSetupCallback)
+        {
+            _connectionString = connectionString;
+            _additionalConnectionSetupCallback = additionalConnectionSetupCallback;
+        }
+
+
+        /// <summary>
+        /// Gets a fresh, open and ready-to-use connection wrapper
+        /// </summary>
+        public async Task<OracleDbConnection> GetConnection()
+        {
+            var connection = new OracleConnection(_connectionString);
+            
+            if (_additionalConnectionSetupCallback != null)
+                _additionalConnectionSetupCallback.Invoke(connection);
+
+            await connection.OpenAsync();
+
+            var currentTransaction = connection.BeginTransaction(IsolationLevel.ReadCommitted);
+
+            return new OracleDbConnection(connection, currentTransaction);
+        }
+    }
+}

--- a/Rebus.Oracle.Devart/Oracle/OracleDbConnection.cs
+++ b/Rebus.Oracle.Devart/Oracle/OracleDbConnection.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Threading.Tasks;
+using Devart.Data.Oracle;
+
+// ReSharper disable EmptyGeneralCatchClause
+#pragma warning disable 1998
+
+namespace Rebus.Oracle
+{
+    /// <summary>
+    /// Wraps an opened <see cref="OracleConnection"/> and makes it easier to work with it
+    /// </summary>
+    public class OracleDbConnection : IDisposable
+    {
+        readonly OracleConnection _currentConnection;
+        OracleTransaction _currentTransaction;
+
+        bool _disposed;
+
+        /// <summary>
+        /// Constructs the wrapper with the given connection and transaction
+        /// </summary>
+        public OracleDbConnection(OracleConnection currentConnection, OracleTransaction currentTransaction)
+        {
+            _currentConnection = currentConnection ?? throw new ArgumentNullException(nameof(currentConnection));
+            _currentTransaction = currentTransaction ?? throw new ArgumentNullException(nameof(currentTransaction));
+        }
+
+        /// <summary>
+        /// Creates a new command, enlisting it in the current transaction
+        /// </summary>
+        public OracleCommand CreateCommand()
+        {
+            var command = _currentConnection.CreateCommand();
+            command.Transaction = _currentTransaction;
+            return command;
+        }
+
+        /// <summary>
+        /// Completes the transaction
+        /// </summary>
+
+        public void Complete()
+        {
+            if (_currentTransaction == null) return;
+            using (_currentTransaction)
+            {
+                _currentTransaction.Commit();
+                _currentTransaction = null;
+            }
+        }
+
+        /// <summary>
+        /// Rolls back the transaction if it hasn't been completed
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed) return;
+
+            try
+            {
+                try
+                {
+                    if (_currentTransaction == null) return;
+                    using (_currentTransaction)
+                    {
+                        try
+                        {
+                            _currentTransaction.Rollback();
+                        }
+                        catch { }
+                        _currentTransaction = null;
+                    }
+                }
+                finally
+                {
+                    _currentConnection.Dispose();
+                }
+            }
+            finally
+            {
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/Rebus.Oracle.Devart/Oracle/Reflection/Ponder.cs
+++ b/Rebus.Oracle.Devart/Oracle/Reflection/Ponder.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Linq.Expressions;
+
+namespace Rebus.Oracle.Reflection
+{
+    class Reflect
+    {
+        public static string Path<T>(Expression<Func<T, object>> expression)
+        {
+            return GetPropertyName(expression);
+        }
+
+        public static object Value(object obj, string path)
+        {
+            var dots = path.Split('.');
+
+            foreach(var dot in dots)
+            {
+                var propertyInfo = obj.GetType().GetProperty(dot);
+                if (propertyInfo == null) return null;
+                obj = propertyInfo.GetValue(obj, new object[0]);
+                if (obj == null) break;
+            }
+
+            return obj;
+        }
+
+        static string GetPropertyName(Expression expression)
+        {
+            if (expression == null) return "";
+
+            if (expression is LambdaExpression)
+            {
+                expression = ((LambdaExpression) expression).Body;
+            }
+
+            if (expression is UnaryExpression)
+            {
+                expression = ((UnaryExpression)expression).Operand;
+            }
+
+            if (expression is MemberExpression)
+            {
+                dynamic memberExpression = expression;
+
+                var lambdaExpression = (Expression)memberExpression.Expression;
+
+                string prefix;
+                if (lambdaExpression != null)
+                {
+                    prefix = GetPropertyName(lambdaExpression);
+                    if (!string.IsNullOrEmpty(prefix))
+                    {
+                        prefix += ".";
+                    }
+                }
+                else
+                {
+                    prefix = "";
+                }
+
+                var propertyName = memberExpression.Member.Name;
+                
+                return prefix + propertyName;
+            }
+
+            return "";
+        }
+    }
+}

--- a/Rebus.Oracle.Devart/Oracle/Sagas/OracleSagaSnapshotStorage.cs
+++ b/Rebus.Oracle.Devart/Oracle/Sagas/OracleSagaSnapshotStorage.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Devart.Data.Oracle;
+using Rebus.Auditing.Sagas;
+using Rebus.Extensions;
+using Rebus.Sagas;
+using Rebus.Serialization;
+
+namespace Rebus.Oracle.Sagas
+{
+    /// <summary>
+    /// Implementation of <see cref="ISagaSnapshotStorage"/> that uses Oracle to store the snapshots
+    /// </summary>
+    public class OracleSagaSnapshotStorage : ISagaSnapshotStorage
+    {
+        readonly ObjectSerializer _objectSerializer = new ObjectSerializer();
+        readonly DictionarySerializer _dictionarySerializer = new DictionarySerializer();
+        readonly OracleConnectionHelper _connectionHelper;
+        readonly string _tableName;
+
+        /// <summary>
+        /// Constructs the storage
+        /// </summary>
+        public OracleSagaSnapshotStorage(OracleConnectionHelper connectionHelper, string tableName)
+        {
+            _connectionHelper = connectionHelper ?? throw new ArgumentNullException(nameof(connectionHelper));
+            _tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
+        }
+
+        /// <summary>
+        /// Saves the <paramref name="sagaData"/> snapshot and the accompanying <paramref name="sagaAuditMetadata"/>
+        /// </summary>
+        public async Task Save(ISagaData sagaData, Dictionary<string, string> sagaAuditMetadata)
+        {
+            using (var connection = await _connectionHelper.GetConnection())
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText =
+                        $@"
+                        INSERT
+                            INTO {_tableName} (id, revision, data, metadata)
+                            VALUES (:id, :revision, :data, :metadata)
+                        ";
+                    command.Parameters.Add("id", OracleDbType.Raw).Value = sagaData.Id;
+                    command.Parameters.Add("revision", OracleDbType.Int64).Value = sagaData.Revision;
+                    command.Parameters.Add("data", OracleDbType.Blob).Value = _objectSerializer.Serialize(sagaData);
+                    command.Parameters.Add("metadata", OracleDbType.Clob).Value =
+                    _dictionarySerializer.SerializeToString(sagaAuditMetadata);
+
+                    await command.ExecuteNonQueryAsync();
+                }
+                
+                connection.Complete();
+            }
+        }
+
+        /// <summary>
+        /// Creates the necessary table if it does not already exist
+        /// </summary>
+        public void EnsureTableIsCreated()
+        {
+            using (var connection = _connectionHelper.GetConnection().Result)
+            {
+                var tableNames = connection.GetTableNames().ToHashSet();
+
+                if (tableNames.Contains(_tableName)) return;
+
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText =
+                        $@"
+                        CREATE TABLE {_tableName} (
+                            id RAW(16) NOT NULL,
+                            revision NUMBER(10) NOT NULL,
+                            metadata CLOB NOT NULL,
+                            data BLOB NOT NULL,
+                            CONSTRAINT {_tableName}_pk PRIMARY KEY (id, revision)
+                        )
+                        ";
+
+                    command.ExecuteNonQuery();
+                }
+
+                connection.Complete();
+            }
+        }
+    }
+}

--- a/Rebus.Oracle.Devart/Oracle/Sagas/OracleSqlSagaStorage.cs
+++ b/Rebus.Oracle.Devart/Oracle/Sagas/OracleSqlSagaStorage.cs
@@ -1,0 +1,392 @@
+﻿// ReSharper disable once RedundantUsingDirective (because .NET Core)
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Rebus.Extensions;
+using System.Reflection;
+using System.Threading.Tasks;
+using Devart.Data.Oracle;
+using Rebus.Exceptions;
+using Rebus.Logging;
+using Rebus.Oracle.Reflection;
+using Rebus.Sagas;
+using Rebus.Serialization;
+
+namespace Rebus.Oracle.Sagas
+{
+    /// <summary>
+    /// Implementation of <see cref="ISagaStorage"/> that uses Oracle to do its thing
+    /// </summary>
+    public class OracleSqlSagaStorage : ISagaStorage
+    {
+        static readonly string IdPropertyName = Reflect.Path<ISagaData>(d => d.Id);
+
+        readonly ObjectSerializer _objectSerializer = new ObjectSerializer();
+        readonly OracleConnectionHelper _connectionHelper;
+        readonly string _dataTableName;
+        readonly string _indexTableName;
+        readonly ILog _log;
+
+        /// <summary>
+        /// Constructs the saga storage
+        /// </summary>
+        public OracleSqlSagaStorage(OracleConnectionHelper connectionHelper, string dataTableName,
+            string indexTableName, IRebusLoggerFactory rebusLoggerFactory)
+        {
+            if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
+            _connectionHelper = connectionHelper ?? throw new ArgumentNullException(nameof(connectionHelper));
+            _dataTableName = dataTableName ?? throw new ArgumentNullException(nameof(dataTableName));
+            _indexTableName = indexTableName ?? throw new ArgumentNullException(nameof(indexTableName));
+            _log = rebusLoggerFactory.GetLogger<OracleSqlSagaStorage>();
+        }
+
+        /// <summary>
+        /// Checks to see if the configured saga data and saga index table exists. If they both exist, we'll continue, if
+        /// neigther of them exists, we'll try to create them. If one of them exists, we'll throw an error.
+        /// </summary>
+        public void EnsureTablesAreCreated()
+        {
+            using (var connection = _connectionHelper.GetConnection().Result)
+            {
+                var tableNames = connection.GetTableNames().ToHashSet();
+
+                var hasDataTable = tableNames.Contains(_dataTableName);
+                var hasIndexTable = tableNames.Contains(_indexTableName);
+
+                if (hasDataTable && hasIndexTable)
+                {
+                    return;
+                }
+
+                if (hasDataTable)
+                {
+                    throw new RebusApplicationException(
+                        $"The saga index table '{_indexTableName}' does not exist, so the automatic saga schema generation tried to run - but there was already a table named '{_dataTableName}', which was supposed to be created as the data table");
+                }
+
+                if (hasIndexTable)
+                {
+                    throw new RebusApplicationException(
+                        $"The saga data table '{_dataTableName}' does not exist, so the automatic saga schema generation tried to run - but there was already a table named '{_indexTableName}', which was supposed to be created as the index table");
+                }
+
+                _log.Info(
+                    "Saga tables {tableName} (data) and {tableName} (index) do not exist - they will be created now",
+                    _dataTableName, _indexTableName);
+
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText =
+                        $@"
+                        CREATE TABLE {_dataTableName} (
+                            id RAW(16) NOT NULL,
+                            revision NUMBER(10) NOT NULL,
+                            data BLOB NOT NULL,
+                            CONSTRAINT {_dataTableName}_pk PRIMARY KEY(id)
+                        )";
+
+                    command.ExecuteNonQuery();
+                }
+
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = $@"
+                        CREATE TABLE {_indexTableName} (
+                            saga_type NVARCHAR2(500) NOT NULL,
+                            key NVARCHAR2(500) NOT NULL,
+                            value NVARCHAR2(2000) NOT NULL,
+                            saga_id RAW(16) NOT NULL,
+                            CONSTRAINT {_indexTableName}_pk PRIMARY KEY(key, value, saga_type)
+                        )";
+                    command.ExecuteNonQuery();
+                }
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = $@"CREATE INDEX {_indexTableName}_IDX ON {_indexTableName} (saga_id)";
+                    command.ExecuteNonQuery();
+                }
+
+                connection.Complete();
+            }
+        }
+
+        /// <summary>
+        /// Finds an already-existing instance of the given saga data type that has a property with the given <paramref name="propertyName" />
+        /// whose value matches <paramref name="propertyValue" />. Returns null if no such instance could be found
+        /// </summary>
+        public async Task<ISagaData> Find(Type sagaDataType, string propertyName, object propertyValue)
+        {
+            using (var connection = await _connectionHelper.GetConnection())
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.InitialLobFetchSize=-1;
+                    if (propertyName == IdPropertyName)
+                    {
+                        command.CommandText = $@"
+                            SELECT s.data 
+                                FROM {_dataTableName} s 
+                                WHERE s.id = :id 
+                            ";
+                        command.Parameters.Add("id", OracleDbType.Raw).Value = ToGuid(propertyValue).ToByteArray();
+                    }
+                    else
+                    {
+                        command.CommandText = $@"
+                            SELECT s.data
+                                FROM Saga_Data s
+                                JOIN Saga_Index i on s.id = i.saga_id 
+                                WHERE i.saga_type = :saga_type AND  i.key = :key AND i.value = :value
+                            ";
+                        command.Parameters.Add(new OracleParameter("key", OracleDbType.NVarChar, propertyName, ParameterDirection.Input));
+                        command.Parameters.Add(new OracleParameter("saga_type", OracleDbType.NVarChar, GetSagaTypeName(sagaDataType), ParameterDirection.Input));
+                        command.Parameters.Add(new OracleParameter("value", OracleDbType.NVarChar, (propertyValue ?? "").ToString(), ParameterDirection.Input));
+                    }
+
+                    var data = (byte[]) command.ExecuteScalar();
+                    //var data = command.ExecuteScalar();
+
+                    if (data == null) return null;
+
+                    try
+                    {
+                        var sagaData = (ISagaData) _objectSerializer.Deserialize(data);
+
+                        if (!sagaDataType.IsInstanceOfType(sagaData))
+                        {
+                            return null;
+                        }
+
+                        return sagaData;
+                    }
+                    catch (Exception exception)
+                    {
+                        var message =
+                            $"An error occurred while attempting to deserialize '{data}' into a {sagaDataType}";
+
+                        throw new RebusApplicationException(exception, message);
+                    }
+                    finally
+                    {
+                        connection.Complete();
+                    }
+                }
+            }
+        }
+
+        static Guid ToGuid(object propertyValue)
+        {
+            return (Guid) Convert.ChangeType(propertyValue, typeof(Guid));
+        }
+
+        /// <summary>
+        /// Inserts the given saga data as a new instance. Throws a <see cref="T:Rebus.Exceptions.ConcurrencyException" /> if another saga data instance
+        /// already exists with a correlation property that shares a value with this saga data.
+        /// </summary>
+        public async Task Insert(ISagaData sagaData, IEnumerable<ISagaCorrelationProperty> correlationProperties)
+        {
+            if (sagaData.Id == Guid.Empty)
+            {
+                throw new InvalidOperationException(
+                    $"Saga data {sagaData.GetType()} has an uninitialized Id property!");
+            }
+
+            if (sagaData.Revision != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Attempted to insert saga data with ID {sagaData.Id} and revision {sagaData.Revision}, but revision must be 0 on first insert!");
+            }
+
+            using (var connection = await _connectionHelper.GetConnection())
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.Parameters.Add("id", OracleDbType.Raw).Value = sagaData.Id;
+                    command.Parameters.Add("revision", OracleDbType.Int64).Value = sagaData.Revision;
+                    command.Parameters.Add("data", OracleDbType.Blob).Value = _objectSerializer.Serialize(sagaData);
+
+                    command.CommandText =
+                        $@"
+                        INSERT 
+                            INTO {_dataTableName} (id, revision, data) 
+                            VALUES (:id, :revision, :data)
+                        ";
+
+                    try
+                    {
+                        command.ExecuteNonQuery();
+                    }
+                    catch (OracleException exception)
+                    {
+                        throw new ConcurrencyException(exception,
+                            $"Saga data {sagaData.GetType()} with ID {sagaData.Id} in table {_dataTableName} could not be inserted!");
+                    }
+                }
+
+                var propertiesToIndex = GetPropertiesToIndex(sagaData, correlationProperties);
+
+                if (propertiesToIndex.Any())
+                {
+                    await CreateIndex(sagaData, connection, propertiesToIndex);
+                }
+
+                connection.Complete();
+            }
+        }
+
+        /// <summary>
+        /// Updates the already-existing instance of the given saga data, throwing a <see cref="T:Rebus.Exceptions.ConcurrencyException" /> if another
+        /// saga data instance exists with a correlation property that shares a value with this saga data, or if the saga data
+        /// instance no longer exists.
+        /// </summary>
+        public async Task Update(ISagaData sagaData, IEnumerable<ISagaCorrelationProperty> correlationProperties)
+        {
+            using (var connection = await _connectionHelper.GetConnection())
+            {
+                var revisionToUpdate = sagaData.Revision;
+
+                sagaData.Revision++;
+
+                var nextRevision = sagaData.Revision;
+
+                // first, delete existing index
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = $@"DELETE FROM {_indexTableName} WHERE saga_id = :id";
+                    command.Parameters.Add("id", OracleDbType.Raw).Value = sagaData.Id;
+                    await command.ExecuteNonQueryAsync();
+                }
+
+                // next, update or insert the saga
+                using (var command = connection.CreateCommand())
+                {
+                    command.Parameters.Add("id", OracleDbType.Raw).Value = sagaData.Id.ToByteArray();
+                    command.Parameters.Add("current_revision", OracleDbType.Int64).Value = revisionToUpdate;
+                    command.Parameters.Add("next_revision", OracleDbType.Int64).Value = nextRevision;
+                    command.Parameters.Add("data", OracleDbType.Raw).Value = _objectSerializer.Serialize(sagaData);
+
+                    command.CommandText =
+                        $@"
+                        UPDATE {_dataTableName} 
+                            SET data = :data, revision = :next_revision 
+                            WHERE id = :id AND revision = :current_revision
+                        ";
+
+                    var rows = await command.ExecuteNonQueryAsync();
+
+                    if (rows == 0)
+                    {
+                        throw new ConcurrencyException(
+                            $"Update of saga with ID {sagaData.Id} did not succeed because someone else beat us to it");
+                    }
+                }
+
+                var propertiesToIndex = GetPropertiesToIndex(sagaData, correlationProperties);
+
+                if (propertiesToIndex.Any())
+                {
+                    await CreateIndex(sagaData, connection, propertiesToIndex);
+                }
+
+                connection.Complete();
+            }
+        }
+
+        /// <summary>
+        /// Deletes the saga data instance, throwing a <see cref="T:Rebus.Exceptions.ConcurrencyException" /> if the instance no longer exists
+        /// </summary>
+        public async Task Delete(ISagaData sagaData)
+        {
+            using (var connection = await _connectionHelper.GetConnection())
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText =
+                        $@"
+                        DELETE 
+                            FROM {_dataTableName} 
+                            WHERE id = :id AND revision = :current_revision
+                        ";
+
+                    command.Parameters.Add("id", OracleDbType.Raw).Value = sagaData.Id;
+                    command.Parameters.Add("current_revision", OracleDbType.Int64).Value = sagaData.Revision;
+
+                    var rows = await command.ExecuteNonQueryAsync();
+
+                    if (rows == 0)
+                    {
+                        throw new ConcurrencyException(
+                            $"Delete of saga with ID {sagaData.Id} did not succeed because someone else beat us to it");
+                    }
+                }
+
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText =
+                        $@"
+                        DELETE 
+                            FROM {_indexTableName} 
+                            WHERE saga_id = :id
+                        ";
+                    command.Parameters.Add("id", OracleDbType.Raw).Value = sagaData.Id;
+
+                    await command.ExecuteNonQueryAsync();
+                }
+
+                connection.Complete();
+            }
+
+            sagaData.Revision++;
+        }
+
+        async Task CreateIndex(ISagaData sagaData, OracleDbConnection connection,
+            IEnumerable<KeyValuePair<string, string>> propertiesToIndex)
+        {
+            var sagaTypeName = GetSagaTypeName(sagaData.GetType());
+            var parameters = propertiesToIndex
+                .Select((p, i) => new
+                {
+                    SagaType = sagaTypeName,
+                    SagaId = sagaData.Id.ToByteArray(),
+                    PropertyName = p.Key,
+                    PropertyValue = p.Value ?? "",
+                })
+                .ToList();
+
+            // lastly, generate new index
+            using (var command = connection.CreateCommand())
+            {
+                // generate batch insert with SQL for each entry in the index
+                command.CommandText =
+                    $@"INSERT INTO {_indexTableName} (saga_type, key, value, saga_id)  VALUES (:saga_type, :key, :value, :saga_id)";
+                command.ExecuteArray(parameters.Count);
+                command.Parameters.Add(new OracleParameter("saga_type", OracleDbType.NVarChar, parameters.Select(x => x.SagaType).ToArray(), ParameterDirection.Input));
+                command.Parameters.Add(new OracleParameter("key", OracleDbType.NVarChar, parameters.Select(x => x.PropertyName).ToArray(), ParameterDirection.Input));
+                command.Parameters.Add(new OracleParameter("value", OracleDbType.NVarChar, parameters.Select(x => x.PropertyValue).ToArray(), ParameterDirection.Input));
+                command.Parameters.Add(new OracleParameter("saga_id", OracleDbType.Raw, parameters.Select(x => x.SagaId).ToArray(), ParameterDirection.Input));
+                await command.ExecuteNonQueryAsync();
+            }
+
+        }
+
+        string GetSagaTypeName(Type sagaDataType)
+        {
+            return sagaDataType.FullName;
+        }
+
+        static List<KeyValuePair<string, string>> GetPropertiesToIndex(ISagaData sagaData, IEnumerable<ISagaCorrelationProperty> correlationProperties)
+        {
+            return correlationProperties
+                .Select(p => p.PropertyName)
+                .Select(path =>
+                {
+                    var value = Reflect.Value(sagaData, path);
+
+                    return new KeyValuePair<string, string>(path, value?.ToString());
+                })
+                .Where(kvp => kvp.Value != null)
+                .ToList();
+        }
+    }
+}

--- a/Rebus.Oracle.Devart/Oracle/Subscriptions/OracleSubscriptionStorage.cs
+++ b/Rebus.Oracle.Devart/Oracle/Subscriptions/OracleSubscriptionStorage.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+using Devart.Data.Oracle;
+using Rebus.Extensions;
+using Rebus.Logging;
+using Rebus.Subscriptions;
+
+namespace Rebus.Oracle.Subscriptions
+{
+    /// <summary>
+    /// Implementation of <see cref="ISubscriptionStorage"/> that uses Oracle to do its thing
+    /// </summary>
+    public class OracleSubscriptionStorage : ISubscriptionStorage
+    {
+        const int UniqueKeyViolation = 1;
+
+        readonly OracleConnectionHelper _connectionHelper;
+        readonly string _tableName;
+        readonly ILog _log;
+
+        /// <summary>
+        /// Constructs the subscription storage, storing subscriptions in the specified <paramref name="tableName"/>.
+        /// If <paramref name="isCentralized"/> is true, subscribing/unsubscribing will be short-circuited by manipulating
+        /// subscriptions directly, instead of requesting via messages
+        /// </summary>
+        public OracleSubscriptionStorage(OracleConnectionHelper connectionHelper, string tableName, bool isCentralized, IRebusLoggerFactory rebusLoggerFactory)
+        {
+            if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
+            _connectionHelper = connectionHelper ?? throw new ArgumentNullException(nameof(connectionHelper));
+            _tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
+            IsCentralized = isCentralized;
+            _log = rebusLoggerFactory.GetLogger<OracleSubscriptionStorage>();
+        }
+
+        /// <summary>
+        /// Creates the subscriptions table if no table with the specified name exists
+        /// </summary>
+        public void EnsureTableIsCreated()
+        {
+            using (var connection = _connectionHelper.GetConnection().Result)
+            {
+                var tableNames = connection.GetTableNames().ToHashSet();
+
+                if (tableNames.Contains(_tableName)) return;
+
+                _log.Info("Table {tableName} does not exist - it will be created now", _tableName);
+
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText =
+                        $@"
+CREATE TABLE {_tableName} (
+	topic VARCHAR(200) NOT NULL,
+	address VARCHAR(200) NOT NULL,
+	PRIMARY KEY (topic,address)
+)";
+                    command.ExecuteNonQuery();
+                }
+
+                connection.Complete();
+            }
+        }
+
+        /// <summary>
+        /// Gets all destination addresses for the given topic
+        /// </summary>
+        public async Task<string[]> GetSubscriberAddresses(string topic)
+        {
+            using (var connection = await _connectionHelper.GetConnection())
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = $@"select address from {_tableName} where topic = :topic";
+
+                command.Parameters.Add(new OracleParameter("topic", OracleDbType.VarChar, topic, ParameterDirection.Input));
+
+                var endpoints = new List<string>();
+
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        endpoints.Add((string)reader["address"]);
+                    }
+                }
+
+                return endpoints.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Registers the given <paramref name="subscriberAddress" /> as a subscriber of the given topic
+        /// </summary>
+        public async Task RegisterSubscriber(string topic, string subscriberAddress)
+        {
+            using (var connection = await _connectionHelper.GetConnection())
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText =
+                    $@"insert into {_tableName} (topic, address) values (:topic, :address)";
+
+                command.Parameters.Add(new OracleParameter("topic", OracleDbType.VarChar, topic, ParameterDirection.Input));
+                command.Parameters.Add(new OracleParameter("address", OracleDbType.VarChar, subscriberAddress, ParameterDirection.Input));
+
+                try
+                {
+                    command.ExecuteNonQuery();
+                }
+                catch (OracleException exception) when (exception.Code == UniqueKeyViolation)
+                {
+                    // it's already there
+                }
+
+                connection.Complete();
+            }
+        }
+
+        /// <summary>
+        /// Unregisters the given <paramref name="subscriberAddress" /> as a subscriber of the given topic
+        /// </summary>
+        public async Task UnregisterSubscriber(string topic, string subscriberAddress)
+        {
+            using (var connection = await _connectionHelper.GetConnection())
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText =
+                    $@"delete from {_tableName} where topic = :topic and address = :address";
+
+                command.Parameters.Add(new OracleParameter("topic", OracleDbType.VarChar, topic, ParameterDirection.Input));
+                command.Parameters.Add(new OracleParameter("address", OracleDbType.VarChar, subscriberAddress, ParameterDirection.Input));
+
+                try
+                {
+                    command.ExecuteNonQuery();
+                }
+                catch (OracleException exception)
+                {
+                    Console.WriteLine(exception);
+                }
+
+                connection.Complete();
+            }
+        }
+
+        /// <summary>
+        /// Gets whether the subscription storage is centralized and thus supports bypassing the usual subscription request
+        /// </summary>
+        public bool IsCentralized { get; }
+    }
+}

--- a/Rebus.Oracle.Devart/Oracle/Timeouts/OracleTimeoutManager.cs
+++ b/Rebus.Oracle.Devart/Oracle/Timeouts/OracleTimeoutManager.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Devart.Data.Oracle;
+using Rebus.Logging;
+using Rebus.Serialization;
+using Rebus.Time;
+using Rebus.Timeouts;
+
+// ReSharper disable AccessToDisposedClosure
+
+#pragma warning disable 1998
+
+namespace Rebus.Oracle.Timeouts
+{
+    /// <summary>
+    /// Implementation of <see cref="ITimeoutManager"/> that uses Oracle to do its thing. Can be used safely by multiple processes competing
+    /// over the same table of timeouts because row-level locking is used when querying for due timeouts.
+    /// </summary>
+    public class OracleTimeoutManager : ITimeoutManager
+    {
+        readonly DictionarySerializer _dictionarySerializer = new DictionarySerializer();
+        readonly OracleConnectionHelper _connectionHelper;
+        readonly string _tableName;
+        readonly ILog _log;
+
+        /// <summary>
+        /// Constructs the timeout manager
+        /// </summary>
+        public OracleTimeoutManager(OracleConnectionHelper connectionHelper, string tableName, IRebusLoggerFactory rebusLoggerFactory)
+        {
+            if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
+            _connectionHelper = connectionHelper ?? throw new ArgumentNullException(nameof(connectionHelper));
+            _tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
+            _log = rebusLoggerFactory.GetLogger<OracleTimeoutManager>();
+        }
+
+        /// <summary>
+        /// Stores the message with the given headers and body data, delaying it until the specified <paramref name="approximateDueTime" />
+        /// </summary>
+        public async Task Defer(DateTimeOffset approximateDueTime, Dictionary<string, string> headers, byte[] body)
+        {
+            using (var connection = await _connectionHelper.GetConnection())
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText =
+                        $@"INSERT INTO {_tableName} (due_time, headers, body) VALUES (:due_time, :headers, :body)"; 
+                    command.Parameters.Add(new OracleParameter("due_time", OracleDbType.TimeStampTZ, approximateDueTime.ToUniversalTime().DateTime, ParameterDirection.Input));
+                    command.Parameters.Add(new OracleParameter("headers", OracleDbType.Clob, _dictionarySerializer.SerializeToString(headers), ParameterDirection.Input));
+                    command.Parameters.Add(new OracleParameter("body", OracleDbType.Blob, body, ParameterDirection.Input));
+                    await command.ExecuteNonQueryAsync();
+                }
+
+                connection.Complete();
+            }
+        }
+
+        /// <summary>
+        /// Gets due messages as of now, given the approximate due time that they were stored with when <see cref="M:Rebus.Timeouts.ITimeoutManager.Defer(System.DateTimeOffset,System.Collections.Generic.Dictionary{System.String,System.String},System.Byte[])" /> was called
+        /// </summary>
+        public async Task<DueMessagesResult> GetDueMessages()
+        {
+            var connection = await _connectionHelper.GetConnection();
+
+            try
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText =
+                        $@"
+                        SELECT
+                            id,
+                            headers, 
+                            body 
+
+                        FROM {_tableName} 
+
+                        WHERE due_time <= :current_time 
+
+                        ORDER BY due_time
+                        FOR UPDATE";
+                    command.Parameters.Add(new OracleParameter("current_time", OracleDbType.TimeStampTZ, RebusTime.Now.ToUniversalTime().DateTime, ParameterDirection.Input));
+
+                    using (var reader = await command.ExecuteReaderAsync())
+                    {
+                        var dueMessages = new List<DueMessage>();
+
+                        while (reader.Read())
+                        {
+                            var id = (long)reader["id"];
+                            var headers = _dictionarySerializer.DeserializeFromString((string) reader["headers"]);
+                            var body = (byte[]) reader["body"];
+
+                            dueMessages.Add(new DueMessage(headers, body, async () =>
+                            {
+                                using (var deleteCommand = connection.CreateCommand())
+                                {
+                                    deleteCommand.CommandText = $@"DELETE FROM {_tableName} WHERE id = :id";
+                                    deleteCommand.Parameters.Add(new OracleParameter("id", OracleDbType.Int64, id, ParameterDirection.Input));
+                                    await deleteCommand.ExecuteNonQueryAsync();
+                                }
+                            }));
+                        }
+
+                        return new DueMessagesResult(dueMessages, async () =>
+                        {
+                            connection.Complete();
+                            connection.Dispose();
+                        });
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                connection.Dispose();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Checks if the configured timeouts table exists - if it doesn't, it will be created.
+        /// </summary>
+        public void EnsureTableIsCreated()
+        {
+            using (var connection = _connectionHelper.GetConnection().Result)
+            {
+                var tableNames = connection.GetTableNames();
+
+                if (tableNames.Contains(_tableName, StringComparer.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
+                _log.Info("Table {tableName} does not exist - it will be created now", _tableName);
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText =
+                        $@"
+                        CREATE TABLE {_tableName} (
+                            id  NUMBER(10) NOT NULL,
+                            due_time TIMESTAMP(7) WITH TIME ZONE NOT NULL,
+                            headers CLOB,
+                            body  BLOB,
+                            CONSTRAINT {_tableName}_pk PRIMARY KEY(id)
+                         )";
+
+                    command.ExecuteNonQuery();
+                }
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText =
+                        $@"CREATE SEQUENCE {_tableName}_SEQ";
+                    command.ExecuteNonQuery();
+                }
+
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText =
+                        $@"
+                        CREATE OR REPLACE TRIGGER {_tableName}_on_insert
+                             BEFORE INSERT ON  {_tableName}
+                             FOR EACH ROW
+                        BEGIN
+                            if :new.Id is null then
+                              :new.id := {_tableName}_seq.nextval;
+                            END IF;
+                        END;
+                        ";
+                    command.ExecuteNonQuery();
+                }
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = $@"
+                        CREATE INDEX {_tableName}_due_idx ON {_tableName} (due_time)";
+
+                    command.ExecuteNonQuery();
+                }
+
+                connection.Complete();
+            }
+        }
+    }
+}

--- a/Rebus.Oracle.Devart/Oracle/Transport/DisabledTimeoutManager.cs
+++ b/Rebus.Oracle.Devart/Oracle/Transport/DisabledTimeoutManager.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Rebus.Extensions;
+using Rebus.Messages;
+using Rebus.Timeouts;
+
+#pragma warning disable 1998
+
+namespace Rebus.Oracle.Transport
+{
+    class DisabledTimeoutManager : ITimeoutManager
+    {
+        public async Task Defer(DateTimeOffset approximateDueTime, Dictionary<string, string> headers, byte[] body)
+        {
+            var messageIdToPrint = headers.GetValueOrNull(Headers.MessageId) ?? "<no message ID>";
+
+            var message =
+                $"Received message with ID {messageIdToPrint} which is supposed to be deferred until {approximateDueTime} -" +
+                " this is a problem, because the internal handling of deferred messages is" +
+                " disabled when using SQL Server as the transport layer in, which" +
+                " case the native support for a specific visibility time is used...";
+
+            throw new InvalidOperationException(message);
+        }
+
+        public async Task<DueMessagesResult> GetDueMessages()
+        {
+            return DueMessagesResult.Empty;
+        }
+    }
+}

--- a/Rebus.Oracle.Devart/Oracle/Transport/OracleTransport.cs
+++ b/Rebus.Oracle.Devart/Oracle/Transport/OracleTransport.cs
@@ -1,0 +1,448 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Devart.Data.Oracle;
+using Rebus.Bus;
+using Rebus.Exceptions;
+using Rebus.Extensions;
+using Rebus.Internals;
+using Rebus.Logging;
+using Rebus.Messages;
+using Rebus.Serialization;
+using Rebus.Threading;
+using Rebus.Time;
+using Rebus.Transport;
+
+namespace Rebus.Oracle.Transport
+{
+    /// <summary>
+    /// Implementation of <see cref="ITransport"/> that uses Oracle to move messages around
+    /// </summary>
+    public class OracleTransport : ITransport, IInitializable, IDisposable
+    {
+        const string CurrentConnectionKey = "oracle-transport-current-connection";
+
+        static readonly HeaderSerializer HeaderSerializer = new HeaderSerializer();
+
+        readonly OracleConnectionHelper _connectionHelper;
+        readonly string _tableName;
+        readonly string _inputQueueName;
+        readonly AsyncBottleneck _receiveBottleneck = new AsyncBottleneck(20);
+        readonly IAsyncTask _expiredMessagesCleanupTask;
+        readonly ILog _log;
+
+        bool _disposed;
+
+        /// <summary>
+        /// Header key of message priority which happens to be supported by this transport
+        /// </summary>
+        public const string MessagePriorityHeaderKey = "rbs2-msg-priority";
+
+        /// <summary>
+        /// Indicates the default interval between which expired messages will be cleaned up
+        /// </summary>
+        public static readonly TimeSpan DefaultExpiredMessagesCleanupInterval = TimeSpan.FromSeconds(20);
+
+        const int OperationCancelledNumber = 3980;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="connectionHelper"></param>
+        /// <param name="tableName"></param>
+        /// <param name="inputQueueName"></param>
+        /// <param name="rebusLoggerFactory"></param>
+        /// <param name="asyncTaskFactory"></param>
+        public OracleTransport(OracleConnectionHelper connectionHelper, string tableName, string inputQueueName, IRebusLoggerFactory rebusLoggerFactory, IAsyncTaskFactory asyncTaskFactory)
+        {
+            if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
+            if (asyncTaskFactory == null) throw new ArgumentNullException(nameof(asyncTaskFactory));
+
+            _log = rebusLoggerFactory.GetLogger<OracleTransport>();
+            _connectionHelper = connectionHelper ?? throw new ArgumentNullException(nameof(connectionHelper));
+            _tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
+            _inputQueueName = inputQueueName;
+            _expiredMessagesCleanupTask = asyncTaskFactory.Create("ExpiredMessagesCleanup", PerformExpiredMessagesCleanupCycle, intervalSeconds: 60);
+
+            ExpiredMessagesCleanupInterval = DefaultExpiredMessagesCleanupInterval;
+        }
+
+        /// <inheritdoc />
+        public void Initialize()
+        {
+            if (_inputQueueName == null) return;
+            _expiredMessagesCleanupTask.Start();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public TimeSpan ExpiredMessagesCleanupInterval { get; set; }
+
+        /// <summary>The SQL transport doesn't really have queues, so this function does nothing</summary>
+        public void CreateQueue(string address)
+        {
+        }
+
+        /// <inheritdoc />
+        public async Task Send(string destinationAddress, TransportMessage message, ITransactionContext context)
+        {
+            var connection = await GetConnection(context);
+            var semaphore = connection.Semaphore;
+
+            // serialize access to the connection
+            await semaphore.WaitAsync();
+
+            try
+            {
+                await InnerSend(destinationAddress, message, connection);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }
+
+        async Task InnerSend(string destinationAddress, TransportMessage message, ConnectionWrapper connection)
+        {
+            using (var command = connection.Connection.CreateCommand())
+            {
+                command.CommandText = $@"
+                    INSERT INTO {_tableName}
+                    (
+                        recipient,
+                        headers,
+                        body,
+                        priority,
+                        visible,
+                        expiration
+                    )
+                    VALUES
+                    (
+                        :recipient,
+                        :headers,
+                        :body,
+                        :priority,
+                        systimestamp(6) + :visible,
+                        systimestamp(6) + :ttlseconds
+                    )";
+
+                var headers = message.Headers.Clone();
+
+                var priority = GetMessagePriority(headers);
+                var initialVisibilityDelay = new TimeSpan(0, 0, 0, GetInitialVisibilityDelay(headers));
+                var ttlSeconds = new TimeSpan(0, 0, 0, GetTtlSeconds(headers));
+
+                // must be last because the other functions on the headers might change them
+                var serializedHeaders = HeaderSerializer.Serialize(headers);
+
+                command.Parameters.Add(new OracleParameter("recipient", OracleDbType.VarChar, destinationAddress, ParameterDirection.Input));
+                command.Parameters.Add(new OracleParameter("headers", OracleDbType.Blob, serializedHeaders, ParameterDirection.Input));
+                command.Parameters.Add(new OracleParameter("body", OracleDbType.Blob, message.Body, ParameterDirection.Input));
+                command.Parameters.Add(new OracleParameter("priority", OracleDbType.Int64, priority, ParameterDirection.Input));
+                command.Parameters.Add(new OracleParameter("visible", OracleDbType.IntervalDS, initialVisibilityDelay, ParameterDirection.Input));
+                command.Parameters.Add(new OracleParameter("ttlseconds", OracleDbType.IntervalDS, ttlSeconds, ParameterDirection.Input));
+
+                await command.ExecuteNonQueryAsync();
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<TransportMessage> Receive(ITransactionContext context, CancellationToken cancellationToken)
+        {
+            using (await _receiveBottleneck.Enter(cancellationToken))
+            {
+                var connection = await GetConnection(context);
+
+                TransportMessage receivedTransportMessage;
+
+                using (var selectCommand = connection.Connection.CreateCommand())
+                {
+                    selectCommand.CommandText = $"rebus_dequeue_{_tableName}";
+                    selectCommand.CommandType = CommandType.StoredProcedure;
+                    selectCommand.Parameters.Add(new OracleParameter("recipientQueue", OracleDbType.VarChar, _inputQueueName, ParameterDirection.Input));
+                    selectCommand.Parameters.Add(new OracleParameter("output", OracleDbType.Cursor ,ParameterDirection.Output));
+                    selectCommand.InitialLobFetchSize = -1;
+
+                    try
+                    {
+                        selectCommand.ExecuteNonQuery();
+                        using (var reader = (selectCommand.Parameters["output"].Value as OracleCursor).GetDataReader()){
+                            if (!await reader.ReadAsync(cancellationToken))
+                            {
+                                return null;
+                            }
+
+                            var headers = reader["headers"];
+                            var headersDictionary = HeaderSerializer.Deserialize((byte[])headers);
+                            var body = (byte[])reader["body"];
+
+                            receivedTransportMessage = new TransportMessage(headersDictionary, body);
+                        }
+                    }
+                    catch (OracleException exception) when (exception.Code == OperationCancelledNumber)
+                    {
+                        // ADO.NET does not throw the right exception when the task gets cancelled - therefore we need to do this:
+                        throw new TaskCanceledException("Receive operation was cancelled", exception);
+                    }
+                }
+
+                return receivedTransportMessage;
+            }
+        }
+
+        async Task PerformExpiredMessagesCleanupCycle()
+        {
+            var results = 0;
+            var stopwatch = Stopwatch.StartNew();
+
+            while (true)
+            {
+                using (var connection = await _connectionHelper.GetConnection())
+                {
+                    int affectedRows;
+
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText =
+                            $@"
+                            delete from {_tableName} 
+                            where recipient = :recipient 
+                            and expiration < systimestamp(6)
+                            ";
+                        command.Parameters.Add(new OracleParameter("recipient", OracleDbType.VarChar, _inputQueueName, ParameterDirection.Input));
+                        affectedRows = await command.ExecuteNonQueryAsync();
+                    }
+
+                    results += affectedRows;
+                    connection.Complete();
+
+                    if (affectedRows == 0) break;
+                }
+            }
+
+            if (results > 0)
+            {
+                _log.Info(
+                    "Performed expired messages cleanup in {0} - {1} expired messages with recipient {2} were deleted",
+                    stopwatch.Elapsed, results, _inputQueueName);
+            }
+        }
+
+        /// <summary>
+        /// Gets the address of the transport
+        /// </summary>
+        public string Address => _inputQueueName;
+
+        /// <summary>
+        /// Creates the necessary table
+        /// </summary>
+        public void EnsureTableIsCreated()
+        {
+            try
+            {
+                CreateSchema();
+            }
+            catch (Exception exception)
+            {
+                throw new RebusApplicationException(exception, $"Error attempting to initialize SQL transport schema with mesages table [dbo].[{_tableName}]");
+            }
+        }
+
+        void CreateSchema()
+        {
+            using (var connection = _connectionHelper.GetConnection().Result)
+            {
+                var tableNames = connection.GetTableNames();
+
+                if (tableNames.Contains(_tableName, StringComparer.OrdinalIgnoreCase))
+                {
+                    _log.Info("Database already contains a table named {tableName} - will not create anything", _tableName);
+                    return;
+                }
+
+                _log.Info("Table {tableName} does not exist - it will be created now", _tableName);
+
+                ExecuteCommands(connection, $@"
+CREATE TABLE {_tableName}
+(
+	id NUMBER(20) NOT NULL,
+	recipient VARCHAR2(255) NOT NULL,
+	priority NUMBER(20) NOT NULL,
+    expiration timestamp(7) with time zone NOT NULL,
+    visible timestamp(7) with time zone NOT NULL,
+	headers blob NOT NULL,
+	body blob NOT NULL
+)
+----
+ALTER TABLE {_tableName} ADD CONSTRAINT {_tableName}_pk PRIMARY KEY(recipient, priority, id)
+----
+CREATE SEQUENCE {_tableName}_SEQ
+----
+CREATE OR REPLACE TRIGGER {_tableName}_on_insert
+     BEFORE INSERT ON  {_tableName}
+     FOR EACH ROW
+BEGIN
+    if :new.Id is null then
+      :new.id := {_tableName}_seq.nextval;
+    END IF;
+END;
+----
+CREATE INDEX idx_receive_{_tableName} ON {_tableName}
+(
+	recipient ASC,
+    expiration ASC,
+    visible ASC
+)
+----
+create or replace PROCEDURE  rebus_dequeue_{_tableName}(recipientQueue IN varchar, output OUT SYS_REFCURSOR ) AS
+  messageId number;
+  readCursor SYS_REFCURSOR; 
+begin
+
+    open readCursor for 
+    SELECT id
+    FROM {_tableName}
+    WHERE recipient = recipientQueue
+            and visible < current_timestamp(6)
+            and expiration > current_timestamp(6)          
+    ORDER BY priority ASC, id ASC
+    for update skip locked;
+    
+    fetch readCursor into messageId;
+    close readCursor;      
+  open output for select * from {_tableName} where id = messageId;
+  delete from {_tableName} where  id = messageId;
+END;
+");
+
+                connection.Complete();
+            }
+        }
+
+        static void ExecuteCommands(OracleDbConnection connection, string sqlCommands)
+        {
+            foreach (var sqlCommand in sqlCommands.Split(new[] { "----" }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = sqlCommand;
+
+                    Execute(command);
+                }
+            }
+        }
+
+        static void Execute(IDbCommand command)
+        {
+            try
+            {
+                command.ExecuteNonQuery();
+            }
+            catch (OracleException exception)
+            {
+                throw new RebusApplicationException(exception, $@"Error executing SQL command
+{command.CommandText}
+");
+            }
+        }
+
+        class ConnectionWrapper : IDisposable
+        {
+            public ConnectionWrapper(OracleDbConnection connection)
+            {
+                Connection = connection;
+                Semaphore = new SemaphoreSlim(1, 1);
+            }
+
+            public OracleDbConnection Connection { get; }
+            public SemaphoreSlim Semaphore { get; }
+
+            public void Dispose()
+            {
+                Connection?.Dispose();
+                Semaphore?.Dispose();
+            }
+        }
+
+        Task<ConnectionWrapper> GetConnection(ITransactionContext context)
+        {
+            return context
+                .GetOrAdd(CurrentConnectionKey,
+                    async () =>
+                    {
+                        var dbConnection = await _connectionHelper.GetConnection();
+                        var connectionWrapper = new ConnectionWrapper(dbConnection);
+                        context.OnCommitted(() =>
+                        {
+                            dbConnection.Complete();
+                            return Task.FromResult(0);
+                        });
+                        context.OnDisposed(() => connectionWrapper.Dispose());
+                        return connectionWrapper;
+                    });
+        }
+
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_disposed) return;
+
+            try
+            {
+                _expiredMessagesCleanupTask.Dispose();
+            }
+            finally
+            {
+                _disposed = true;
+            }
+        }
+
+        static int GetMessagePriority(Dictionary<string, string> headers)
+        {
+            var valueOrNull = headers.GetValueOrNull(MessagePriorityHeaderKey);
+            if (valueOrNull == null) return 0;
+
+            try
+            {
+                return int.Parse(valueOrNull);
+            }
+            catch (Exception exception)
+            {
+                throw new FormatException($"Could not parse '{valueOrNull}' into an Int32!", exception);
+            }
+        }
+
+        static int GetInitialVisibilityDelay(IDictionary<string, string> headers)
+        {
+            if (!headers.TryGetValue(Headers.DeferredUntil, out var deferredUntilDateTimeOffsetString))
+            {
+                return 0;
+            }
+
+            var deferredUntilTime = deferredUntilDateTimeOffsetString.ToDateTimeOffset();
+
+            headers.Remove(Headers.DeferredUntil);
+
+            return (int)(deferredUntilTime - RebusTime.Now).TotalSeconds;
+        }
+
+        static int GetTtlSeconds(IReadOnlyDictionary<string, string> headers)
+        {
+            const int defaultTtlSecondsAbout60Years = int.MaxValue;
+
+            if (!headers.ContainsKey(Headers.TimeToBeReceived))
+                return defaultTtlSecondsAbout60Years;
+
+            var timeToBeReceivedStr = headers[Headers.TimeToBeReceived];
+            var timeToBeReceived = TimeSpan.Parse(timeToBeReceivedStr);
+
+            return (int)timeToBeReceived.TotalSeconds;
+        }
+    }
+}

--- a/Rebus.Oracle.Devart/Rebus.Oracle.Devart.csproj
+++ b/Rebus.Oracle.Devart/Rebus.Oracle.Devart.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Rebus.Oracle.Devart</Description>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <Authors>Jeffrey Wilbur</Authors>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Devart.Data.Oracle" Version="9.5.454" />
+    <PackageReference Include="Rebus" Version="4.2.1" />
+  </ItemGroup>
+
+</Project>

--- a/Rebus.Oracle.sln
+++ b/Rebus.Oracle.sln
@@ -14,6 +14,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rebus.Oracle", "Rebus.Oracl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rebus.Oracle.Tests", "Rebus.Oracle.Tests\Rebus.Oracle.Tests.csproj", "{51F26FA8-D596-4A51-AF57-AF500DD8FB30}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rebus.Oracle.Devart", "Rebus.Oracle.Devart\Rebus.Oracle.Devart.csproj", "{F57601BB-6DDA-4362-9AA5-8BE5D6A184E5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +30,10 @@ Global
 		{51F26FA8-D596-4A51-AF57-AF500DD8FB30}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{51F26FA8-D596-4A51-AF57-AF500DD8FB30}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51F26FA8-D596-4A51-AF57-AF500DD8FB30}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F57601BB-6DDA-4362-9AA5-8BE5D6A184E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F57601BB-6DDA-4362-9AA5-8BE5D6A184E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F57601BB-6DDA-4362-9AA5-8BE5D6A184E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F57601BB-6DDA-4362-9AA5-8BE5D6A184E5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
We needed a Devart implementation for those using their driver rather than the official Oracle managed access driver (particularly in Net Core projects). This port facilitates that.