### PR TITLE
Add ambient transaction support

### DIFF
--- a/Rebus.Oracle.Devart/Config/OracleConfigurationExtensions.cs
+++ b/Rebus.Oracle.Devart/Config/OracleConfigurationExtensions.cs
@@ -22,11 +22,11 @@ namespace Rebus.Config
         /// </summary>
         public static void StoreInOracle(this StandardConfigurer<ISagaSnapshotStorage> configurer,
             string connectionString, string tableName, bool automaticallyCreateTables = true, 
-            Action<OracleConnection> additionalConnectionSetup = null)
+            Action<OracleConnection> additionalConnectionSetup = null, bool enlistInAmbientTransaction = false)
         {
             configurer.Register(c =>
             {
-                var sagaStorage = new OracleSagaSnapshotStorage(new OracleConnectionHelper(connectionString, additionalConnectionSetup), tableName);
+                var sagaStorage = new OracleSagaSnapshotStorage(new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction), tableName);
 
                 if (automaticallyCreateTables)
                 {
@@ -42,12 +42,13 @@ namespace Rebus.Config
         /// </summary>
         public static void StoreInOracle(this StandardConfigurer<ISagaStorage> configurer,
             string connectionString, string dataTableName, string indexTableName,
-            bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null)
+            bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null,
+            bool enlistInAmbientTransaction = false)
         {
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var sagaStorage = new OracleSqlSagaStorage(new OracleConnectionHelper(connectionString, additionalConnectionSetup), dataTableName, indexTableName, rebusLoggerFactory);
+                var sagaStorage = new OracleSqlSagaStorage(new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction), dataTableName, indexTableName, rebusLoggerFactory);
 
                 if (automaticallyCreateTables)
                 {
@@ -62,12 +63,12 @@ namespace Rebus.Config
         /// Configures Rebus to use Oracle to store timeouts.
         /// </summary>
         public static void StoreInOracle(this StandardConfigurer<ITimeoutManager> configurer, string connectionString, string tableName, 
-            bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null)
+            bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null, bool enlistInAmbientTransaction = false)
         {
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var subscriptionStorage = new OracleTimeoutManager(new OracleConnectionHelper(connectionString, additionalConnectionSetup), tableName, rebusLoggerFactory);
+                var subscriptionStorage = new OracleTimeoutManager(new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction), tableName, rebusLoggerFactory);
 
                 if (automaticallyCreateTables)
                 {
@@ -84,12 +85,13 @@ namespace Rebus.Config
         /// default behavior.
         /// </summary>
         public static void StoreInOracle(this StandardConfigurer<ISubscriptionStorage> configurer,
-            string connectionString, string tableName, bool isCentralized = false, bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null)
+            string connectionString, string tableName, bool isCentralized = false, bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null,
+            bool enlistInAmbientTransaction = false)
         {
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var connectionHelper = new OracleConnectionHelper(connectionString, additionalConnectionSetup);
+                var connectionHelper = new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction);
                 var subscriptionStorage = new OracleSubscriptionStorage(
                     connectionHelper, tableName, isCentralized, rebusLoggerFactory);
 

--- a/Rebus.Oracle.Devart/Config/OracleTransportConfigurationExtensions.cs
+++ b/Rebus.Oracle.Devart/Config/OracleTransportConfigurationExtensions.cs
@@ -20,9 +20,9 @@ namespace Rebus.Config
         /// store messages, and the "queue" specified by <paramref name="inputQueueName"/> will be used when querying for messages.
         /// The message table will automatically be created if it does not exist.
         /// </summary>
-        public static void UseOracle(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionOrConnectionStringName, string tableName, string inputQueueName)
+        public static void UseOracle(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionOrConnectionStringName, string tableName, string inputQueueName, bool enlistInAmbientTransaction = false)
         {
-            Configure(configurer, loggerFactory => new OracleConnectionHelper(connectionStringOrConnectionOrConnectionStringName), tableName, inputQueueName);
+            Configure(configurer, loggerFactory => new OracleConnectionHelper(connectionStringOrConnectionOrConnectionStringName, enlistInAmbientTransaction), tableName, inputQueueName);
         }
 
         /// <summary>
@@ -30,9 +30,9 @@ namespace Rebus.Config
         /// The table specified by <paramref name="tableName"/> will be used to store messages.
         /// The message table will automatically be created if it does not exist.
         /// </summary>
-        public static void UseOracleAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionStringName, string tableName)
+        public static void UseOracleAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionStringName, string tableName, bool enlistInAmbientTransaction = false)
         {
-            Configure(configurer, loggerFactory => new OracleConnectionHelper(connectionStringOrConnectionStringName), tableName, null);
+            Configure(configurer, loggerFactory => new OracleConnectionHelper(connectionStringOrConnectionStringName, enlistInAmbientTransaction), tableName, null);
 
             OneWayClientBackdoor.ConfigureOneWayClient(configurer);
         }

--- a/Rebus.Oracle.Devart/Oracle/OracleConnectionHelper.cs
+++ b/Rebus.Oracle.Devart/Oracle/OracleConnectionHelper.cs
@@ -39,7 +39,8 @@ namespace Rebus.Oracle
         /// <param name="additionalConnectionSetupCallback">Additional setup to be performed prior to opening each connection. 
         /// Useful for configuring client certificate authentication, as well as set up other callbacks.</param>
         /// <param name="enlistInAmbientTransaction">If <c>true</c> the connection will be enlisted in the ambient transaction if it exists, else it will create an OracleTransaction and enlist in it</param>
-        public OracleConnectionHelper(string connectionString, Action<OracleConnection> additionalConnectionSetupCallback, bool enlistInAmbientTransaction)
+        public OracleConnectionHelper(string connectionString,
+            Action<OracleConnection> additionalConnectionSetupCallback, bool enlistInAmbientTransaction)
         {
             _connectionString = connectionString;
             _additionalConnectionSetupCallback = additionalConnectionSetupCallback;
@@ -52,62 +53,48 @@ namespace Rebus.Oracle
         /// </summary>
         public OracleDbConnection GetConnection()
         {
-            OracleConnection connection = null;
-            OracleTransaction transaction = null;
+            var connection = new OracleConnection(_connectionString);
             try
             {
-                if (!_enlistInAmbientTransaction)
-                {
-                    connection = CreateOracleConnectionSuppressingAPossibleAmbientTransaction();
-                    transaction = connection.BeginTransaction(IsolationLevel.ReadCommitted);
-                }
-                else
-                {
-                    connection = CreateOracleConnectionInAPossiblyAmbientTransaction();
-                }
-
-                return new OracleDbConnection(connection, transaction);
+                return !_enlistInAmbientTransaction
+                    ? CreateOracleDbConnection(connection)
+                    : CreateOracleDbConnectionInAPossiblyAmbientTransaction(connection);
             }
             catch (Exception)
             {
-                connection?.Dispose();
+                connection.Dispose();
                 throw;
             }
         }
 
-        private OracleConnection CreateOracleConnectionInAPossiblyAmbientTransaction()
+        private OracleDbConnection CreateOracleDbConnectionInAPossiblyAmbientTransaction(OracleConnection connection)
         {
-            var connection = new OracleConnection(_connectionString);
-
             _additionalConnectionSetupCallback?.Invoke(connection);
 
             // do not use Async here! it would cause the tx scope to be disposed on another thread than the one that created it
             connection.Open();
 
-            var transaction = System.Transactions.Transaction.Current;
-            if (transaction != null)
+            var ambientTransaction = System.Transactions.Transaction.Current;
+            if (ambientTransaction != null)
             {
-                connection.EnlistTransaction(transaction);
+                connection.EnlistTransaction(ambientTransaction);
+                return new OracleDbConnection(connection, null);
             }
 
-            return connection;
+            var transaction = connection.BeginTransaction(IsolationLevel.ReadCommitted);
+            return new OracleDbConnection(connection, transaction);
         }
 
-        private OracleConnection CreateOracleConnectionSuppressingAPossibleAmbientTransaction()
+        private OracleDbConnection CreateOracleDbConnection(OracleConnection connection)
         {
-            OracleConnection connection;
+            _additionalConnectionSetupCallback?.Invoke(connection);
 
-            using (new System.Transactions.TransactionScope(System.Transactions.TransactionScopeOption.Suppress))
-            {
-                connection = new OracleConnection(_connectionString);
+            // do not use Async here! it would cause the tx scope to be disposed on another thread than the one that created it
+            connection.Open();
 
-                _additionalConnectionSetupCallback?.Invoke(connection);
+            var currentTransaction = connection.BeginTransaction(IsolationLevel.ReadCommitted);
 
-                // do not use Async here! it would cause the tx scope to be disposed on another thread than the one that created it
-                connection.Open();
-            }
-
-            return connection;
+            return new OracleDbConnection(connection, currentTransaction);
         }
     }
 }

--- a/Rebus.Oracle.Devart/Oracle/OracleConnectionHelper.cs
+++ b/Rebus.Oracle.Devart/Oracle/OracleConnectionHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Data;
-using System.Threading.Tasks;
 using Devart.Data.Oracle;
 
 namespace Rebus.Oracle
@@ -12,6 +11,7 @@ namespace Rebus.Oracle
     {
         readonly string _connectionString;
         private readonly Action<OracleConnection> _additionalConnectionSetupCallback;
+        private readonly bool _enlistInAmbientTransaction;
 
         /// <summary>
         /// Constructs this thingie
@@ -27,28 +27,76 @@ namespace Rebus.Oracle
         /// <param name="connectionString">Connection string.</param>
         /// <param name="additionalConnectionSetupCallback">Additional setup to be performed prior to opening each connection. 
         /// Useful for configuring client certificate authentication, as well as set up other callbacks.</param>
-        public OracleConnectionHelper(string connectionString, Action<OracleConnection> additionalConnectionSetupCallback)
+        /// <param name="enlistInAmbientTransaction">If <c>true</c> the connection will be enlisted in the ambient transaction if it exists, else it will create an OracleTransaction and enlist in it</param>
+        public OracleConnectionHelper(string connectionString, Action<OracleConnection> additionalConnectionSetupCallback, bool enlistInAmbientTransaction)
         {
             _connectionString = connectionString;
             _additionalConnectionSetupCallback = additionalConnectionSetupCallback;
+            _enlistInAmbientTransaction = enlistInAmbientTransaction;
         }
 
-
+        
         /// <summary>
         /// Gets a fresh, open and ready-to-use connection wrapper
         /// </summary>
-        public async Task<OracleDbConnection> GetConnection()
+        public OracleDbConnection GetConnection()
+        {
+            OracleConnection connection = null;
+            OracleTransaction transaction = null;
+            try
+            {
+                if (!_enlistInAmbientTransaction)
+                {
+                    connection = CreateOracleConnectionSuppressingAPossibleAmbientTransaction();
+                    transaction = connection.BeginTransaction(IsolationLevel.ReadCommitted);
+                }
+                else
+                {
+                    connection = CreateOracleConnectionInAPossiblyAmbientTransaction();
+                }
+
+                return new OracleDbConnection(connection, transaction);
+            }
+            catch (Exception)
+            {
+                connection?.Dispose();
+                throw;
+            }
+        }
+
+        private OracleConnection CreateOracleConnectionInAPossiblyAmbientTransaction()
         {
             var connection = new OracleConnection(_connectionString);
-            
-            if (_additionalConnectionSetupCallback != null)
-                _additionalConnectionSetupCallback.Invoke(connection);
 
-            await connection.OpenAsync();
+            _additionalConnectionSetupCallback?.Invoke(connection);
 
-            var currentTransaction = connection.BeginTransaction(IsolationLevel.ReadCommitted);
+            // do not use Async here! it would cause the tx scope to be disposed on another thread than the one that created it
+            connection.Open();
 
-            return new OracleDbConnection(connection, currentTransaction);
+            var transaction = System.Transactions.Transaction.Current;
+            if (transaction != null)
+            {
+                connection.EnlistTransaction(transaction);
+            }
+
+            return connection;
+        }
+
+        private OracleConnection CreateOracleConnectionSuppressingAPossibleAmbientTransaction()
+        {
+            OracleConnection connection;
+
+            using (new System.Transactions.TransactionScope(System.Transactions.TransactionScopeOption.Suppress))
+            {
+                connection = new OracleConnection(_connectionString);
+
+                _additionalConnectionSetupCallback?.Invoke(connection);
+
+                // do not use Async here! it would cause the tx scope to be disposed on another thread than the one that created it
+                connection.Open();
+            }
+
+            return connection;
         }
     }
 }

--- a/Rebus.Oracle.Devart/Oracle/OracleConnectionHelper.cs
+++ b/Rebus.Oracle.Devart/Oracle/OracleConnectionHelper.cs
@@ -54,6 +54,12 @@ namespace Rebus.Oracle
         public OracleDbConnection GetConnection()
         {
             var connection = new OracleConnection(_connectionString);
+
+            _additionalConnectionSetupCallback?.Invoke(connection);
+
+            // do not use Async here! it would cause the tx scope to be disposed on another thread than the one that created it
+            connection.Open();
+
             try
             {
                 return !_enlistInAmbientTransaction
@@ -69,11 +75,6 @@ namespace Rebus.Oracle
 
         private OracleDbConnection CreateOracleDbConnectionInAPossiblyAmbientTransaction(OracleConnection connection)
         {
-            _additionalConnectionSetupCallback?.Invoke(connection);
-
-            // do not use Async here! it would cause the tx scope to be disposed on another thread than the one that created it
-            connection.Open();
-
             var ambientTransaction = System.Transactions.Transaction.Current;
             if (ambientTransaction != null)
             {
@@ -87,13 +88,7 @@ namespace Rebus.Oracle
 
         private OracleDbConnection CreateOracleDbConnection(OracleConnection connection)
         {
-            _additionalConnectionSetupCallback?.Invoke(connection);
-
-            // do not use Async here! it would cause the tx scope to be disposed on another thread than the one that created it
-            connection.Open();
-
             var currentTransaction = connection.BeginTransaction(IsolationLevel.ReadCommitted);
-
             return new OracleDbConnection(connection, currentTransaction);
         }
     }

--- a/Rebus.Oracle.Devart/Oracle/OracleConnectionHelper.cs
+++ b/Rebus.Oracle.Devart/Oracle/OracleConnectionHelper.cs
@@ -16,9 +16,20 @@ namespace Rebus.Oracle
         /// <summary>
         /// Constructs this thingie
         /// </summary>
+        /// <param name="connectionString">Connection string.</param>
         public OracleConnectionHelper(string connectionString)
         {
             _connectionString = connectionString;
+        }
+
+        /// <summary>
+        /// Constructs this thingie
+        /// </summary>
+        /// <param name="connectionString">Connection string.</param>
+        /// <param name="enlistInAmbientTransaction">If <c>true</c> the connection will be enlisted in the ambient transaction if it exists, else it will create an OracleTransaction and enlist in it</param>
+        public OracleConnectionHelper(string connectionString, bool enlistInAmbientTransaction)
+            : this(connectionString, null, enlistInAmbientTransaction)
+        {
         }
 
         /// <summary>
@@ -35,7 +46,7 @@ namespace Rebus.Oracle
             _enlistInAmbientTransaction = enlistInAmbientTransaction;
         }
 
-        
+
         /// <summary>
         /// Gets a fresh, open and ready-to-use connection wrapper
         /// </summary>

--- a/Rebus.Oracle.Devart/Oracle/OracleDbConnection.cs
+++ b/Rebus.Oracle.Devart/Oracle/OracleDbConnection.cs
@@ -22,7 +22,7 @@ namespace Rebus.Oracle
         public OracleDbConnection(OracleConnection currentConnection, OracleTransaction currentTransaction)
         {
             _currentConnection = currentConnection ?? throw new ArgumentNullException(nameof(currentConnection));
-            _currentTransaction = currentTransaction ?? throw new ArgumentNullException(nameof(currentTransaction));
+            _currentTransaction = currentTransaction;
         }
 
         /// <summary>

--- a/Rebus.Oracle.Devart/Oracle/OracleDbConnection.cs
+++ b/Rebus.Oracle.Devart/Oracle/OracleDbConnection.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using Devart.Data.Oracle;
 
 // ReSharper disable EmptyGeneralCatchClause

--- a/Rebus.Oracle.Devart/Oracle/Sagas/OracleSagaSnapshotStorage.cs
+++ b/Rebus.Oracle.Devart/Oracle/Sagas/OracleSagaSnapshotStorage.cs
@@ -33,7 +33,7 @@ namespace Rebus.Oracle.Sagas
         /// </summary>
         public async Task Save(ISagaData sagaData, Dictionary<string, string> sagaAuditMetadata)
         {
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             {
                 using (var command = connection.CreateCommand())
                 {
@@ -61,7 +61,7 @@ namespace Rebus.Oracle.Sagas
         /// </summary>
         public void EnsureTableIsCreated()
         {
-            using (var connection = _connectionHelper.GetConnection().Result)
+            using (var connection = _connectionHelper.GetConnection())
             {
                 var tableNames = connection.GetTableNames().ToHashSet();
 

--- a/Rebus.Oracle.Devart/Oracle/Sagas/OracleSqlSagaStorage.cs
+++ b/Rebus.Oracle.Devart/Oracle/Sagas/OracleSqlSagaStorage.cs
@@ -86,7 +86,7 @@ namespace Rebus.Oracle.Sagas
                             CONSTRAINT {_dataTableName}_pk PRIMARY KEY(id)
                         )";
 
-                    command.ExecuteNonQueryAsync();
+                    command.ExecuteNonQuery();
                 }
 
                 using (var command = connection.CreateCommand())

--- a/Rebus.Oracle.Devart/Oracle/Sagas/OracleSqlSagaStorage.cs
+++ b/Rebus.Oracle.Devart/Oracle/Sagas/OracleSqlSagaStorage.cs
@@ -47,7 +47,7 @@ namespace Rebus.Oracle.Sagas
         /// </summary>
         public void EnsureTablesAreCreated()
         {
-            using (var connection = _connectionHelper.GetConnection().Result)
+            using (var connection = _connectionHelper.GetConnection())
             {
                 var tableNames = connection.GetTableNames();
 
@@ -86,7 +86,7 @@ namespace Rebus.Oracle.Sagas
                             CONSTRAINT {_dataTableName}_pk PRIMARY KEY(id)
                         )";
 
-                    command.ExecuteNonQuery();
+                    command.ExecuteNonQueryAsync();
                 }
 
                 using (var command = connection.CreateCommand())
@@ -117,7 +117,7 @@ namespace Rebus.Oracle.Sagas
         /// </summary>
         public async Task<ISagaData> Find(Type sagaDataType, string propertyName, object propertyValue)
         {
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             {
                 using (var command = connection.CreateCommand())
                 {
@@ -144,8 +144,7 @@ namespace Rebus.Oracle.Sagas
                         command.Parameters.Add(new OracleParameter("value", OracleDbType.NVarChar, (propertyValue ?? "").ToString(), ParameterDirection.Input));
                     }
 
-                    var data = (byte[]) command.ExecuteScalar();
-                    //var data = command.ExecuteScalar();
+                    var data = (byte[]) await command.ExecuteScalarAsync();
 
                     if (data == null) return null;
 
@@ -198,7 +197,7 @@ namespace Rebus.Oracle.Sagas
                     $"Attempted to insert saga data with ID {sagaData.Id} and revision {sagaData.Revision}, but revision must be 0 on first insert!");
             }
 
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             {
                 using (var command = connection.CreateCommand())
                 {
@@ -215,7 +214,7 @@ namespace Rebus.Oracle.Sagas
 
                     try
                     {
-                        command.ExecuteNonQuery();
+                        await command.ExecuteNonQueryAsync();
                     }
                     catch (OracleException exception)
                     {
@@ -242,7 +241,7 @@ namespace Rebus.Oracle.Sagas
         /// </summary>
         public async Task Update(ISagaData sagaData, IEnumerable<ISagaCorrelationProperty> correlationProperties)
         {
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             {
                 var revisionToUpdate = sagaData.Revision;
 
@@ -298,7 +297,7 @@ namespace Rebus.Oracle.Sagas
         /// </summary>
         public async Task Delete(ISagaData sagaData)
         {
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             {
                 using (var command = connection.CreateCommand())
                 {

--- a/Rebus.Oracle.Devart/Oracle/Subscriptions/OracleSubscriptionStorage.cs
+++ b/Rebus.Oracle.Devart/Oracle/Subscriptions/OracleSubscriptionStorage.cs
@@ -41,7 +41,7 @@ namespace Rebus.Oracle.Subscriptions
         /// </summary>
         public void EnsureTableIsCreated()
         {
-            using (var connection = _connectionHelper.GetConnection().Result)
+            using (var connection = _connectionHelper.GetConnection())
             {
                 var tableNames = connection.GetTableNames();
 
@@ -70,7 +70,7 @@ CREATE TABLE {_tableName} (
         /// </summary>
         public async Task<string[]> GetSubscriberAddresses(string topic)
         {
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             using (var command = connection.CreateCommand())
             {
                 command.CommandText = $@"select address from {_tableName} where topic = :topic";
@@ -79,7 +79,7 @@ CREATE TABLE {_tableName} (
 
                 var endpoints = new List<string>();
 
-                using (var reader = command.ExecuteReader())
+                using (var reader = await command.ExecuteReaderAsync())
                 {
                     while (reader.Read())
                     {
@@ -96,7 +96,7 @@ CREATE TABLE {_tableName} (
         /// </summary>
         public async Task RegisterSubscriber(string topic, string subscriberAddress)
         {
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             using (var command = connection.CreateCommand())
             {
                 command.CommandText =
@@ -107,7 +107,7 @@ CREATE TABLE {_tableName} (
 
                 try
                 {
-                    command.ExecuteNonQuery();
+                    await command.ExecuteNonQueryAsync();
                 }
                 catch (OracleException exception) when (exception.Code == UniqueKeyViolation)
                 {
@@ -123,7 +123,7 @@ CREATE TABLE {_tableName} (
         /// </summary>
         public async Task UnregisterSubscriber(string topic, string subscriberAddress)
         {
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             using (var command = connection.CreateCommand())
             {
                 command.CommandText =
@@ -134,7 +134,7 @@ CREATE TABLE {_tableName} (
 
                 try
                 {
-                    command.ExecuteNonQuery();
+                    await command.ExecuteNonQueryAsync();
                 }
                 catch (OracleException exception)
                 {

--- a/Rebus.Oracle.Devart/Oracle/Timeouts/OracleTimeoutManager.cs
+++ b/Rebus.Oracle.Devart/Oracle/Timeouts/OracleTimeoutManager.cs
@@ -148,7 +148,7 @@ namespace Rebus.Oracle.Timeouts
                             CONSTRAINT {_tableName}_pk PRIMARY KEY(id)
                          )";
 
-                    command.ExecuteNonQueryAsync();
+                    command.ExecuteNonQuery();
                 }
                 using (var command = connection.CreateCommand())
                 {

--- a/Rebus.Oracle.Devart/Oracle/Timeouts/OracleTimeoutManager.cs
+++ b/Rebus.Oracle.Devart/Oracle/Timeouts/OracleTimeoutManager.cs
@@ -43,7 +43,7 @@ namespace Rebus.Oracle.Timeouts
         /// </summary>
         public async Task Defer(DateTimeOffset approximateDueTime, Dictionary<string, string> headers, byte[] body)
         {
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             {
                 using (var command = connection.CreateCommand())
                 {
@@ -64,7 +64,7 @@ namespace Rebus.Oracle.Timeouts
         /// </summary>
         public async Task<DueMessagesResult> GetDueMessages()
         {
-            var connection = await _connectionHelper.GetConnection();
+            var connection = _connectionHelper.GetConnection();
 
             try
             {
@@ -126,7 +126,7 @@ namespace Rebus.Oracle.Timeouts
         /// </summary>
         public void EnsureTableIsCreated()
         {
-            using (var connection = _connectionHelper.GetConnection().Result)
+            using (var connection = _connectionHelper.GetConnection())
             {
                 var tableNames = connection.GetTableNames();
 
@@ -148,7 +148,7 @@ namespace Rebus.Oracle.Timeouts
                             CONSTRAINT {_tableName}_pk PRIMARY KEY(id)
                          )";
 
-                    command.ExecuteNonQuery();
+                    command.ExecuteNonQueryAsync();
                 }
                 using (var command = connection.CreateCommand())
                 {

--- a/Rebus.Oracle.Devart/Oracle/Transport/OracleTransport.cs
+++ b/Rebus.Oracle.Devart/Oracle/Transport/OracleTransport.cs
@@ -202,7 +202,7 @@ namespace Rebus.Oracle.Transport
 
             while (true)
             {
-                using (var connection = await _connectionHelper.GetConnection())
+                using (var connection = _connectionHelper.GetConnection())
                 {
                     int affectedRows;
 
@@ -255,7 +255,7 @@ namespace Rebus.Oracle.Transport
 
         void CreateSchema()
         {
-            using (var connection = _connectionHelper.GetConnection().Result)
+            using (var connection = _connectionHelper.GetConnection())
             {
                 var tableNames = connection.GetTableNames();
 
@@ -375,7 +375,8 @@ END;
                 .GetOrAdd(CurrentConnectionKey,
                     async () =>
                     {
-                        var dbConnection = await _connectionHelper.GetConnection();
+                        await Task.CompletedTask;
+                        var dbConnection = _connectionHelper.GetConnection();
                         var connectionWrapper = new ConnectionWrapper(dbConnection);
                         context.OnCommitted(() =>
                         {

--- a/Rebus.Oracle.Tests/Integration/TestOracleAllTheWay.cs
+++ b/Rebus.Oracle.Tests/Integration/TestOracleAllTheWay.cs
@@ -56,6 +56,7 @@ namespace Rebus.Oracle.Tests.Integration
 
             _activator.Handle<string>(async message =>
             {
+                await Task.CompletedTask;
                 Interlocked.Increment(ref receivedMessageCount);
                 Console.WriteLine("w00000t! Got message: {0}", message);
                 gotTheMessage.Set();
@@ -80,6 +81,7 @@ namespace Rebus.Oracle.Tests.Integration
 
             _activator.Handle<string>(async message =>
             {
+                await Task.CompletedTask;
                 Interlocked.Increment(ref receivedMessageCount);
                 Console.WriteLine("w00000t! Got message: {0}", message);
                 gotTheMessage.Set();

--- a/Rebus.Oracle.Tests/Integration/TestOracleAllTheWay.cs
+++ b/Rebus.Oracle.Tests/Integration/TestOracleAllTheWay.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Exceptions;
+using Rebus.Tests.Contracts;
+using Rebus.Tests.Contracts.Extensions;
+
+namespace Rebus.Oracle.Tests.Integration
+{
+    [TestFixture, Category(Categories.Oracle)]
+    public class TestOracleAllTheWay : FixtureBase
+    {
+        static readonly string ConnectionString = OracleTestHelper.ConnectionString;
+
+        BuiltinHandlerActivator _activator;
+        IBus _bus;
+
+        protected override void SetUp()
+        {
+            DropTables();
+
+            _activator = new BuiltinHandlerActivator();
+
+            Using(_activator);
+
+            _bus = Configure.With(_activator)
+                .Transport(x => x.UseOracle(ConnectionString, "transports", "test.input", true))
+                .Options(x =>
+                {
+                    x.SetNumberOfWorkers(1);
+                    x.SetMaxParallelism(1);
+                })
+                .Start();
+        }
+
+        protected override void TearDown()
+        {
+            DropTables();
+        }
+
+        static void DropTables()
+        {
+            OracleTestHelper.DropTableAndSequence("transports");
+        }
+
+        [Test]
+        public async Task SendAndReceiveOneSingleMessage()
+        {
+            var gotTheMessage = new ManualResetEvent(false);
+            var receivedMessageCount = 0;
+
+            _activator.Handle<string>(async message =>
+            {
+                Interlocked.Increment(ref receivedMessageCount);
+                Console.WriteLine("w00000t! Got message: {0}", message);
+                gotTheMessage.Set();
+            });
+
+            await _bus.SendLocal("hej med dig min ven!");
+
+            gotTheMessage.WaitOrDie(TimeSpan.FromSeconds(10));
+
+            await Task.Delay(500);
+
+            Assert.That(receivedMessageCount, Is.EqualTo(1));
+        }
+
+        [TestCase(true, false, true)]
+        [TestCase(false, false, false)]
+        [TestCase(true, true, false)]
+        public async Task SendAndReceiveOneSingleMessageInAnAmbientTransaction(bool completeTransaction, bool throwInsideTransactionScope, bool expectMessageReceived)
+        {
+            var gotTheMessage = new ManualResetEvent(false);
+            var receivedMessageCount = 0;
+
+            _activator.Handle<string>(async message =>
+            {
+                Interlocked.Increment(ref receivedMessageCount);
+                Console.WriteLine("w00000t! Got message: {0}", message);
+                gotTheMessage.Set();
+            });
+
+            try
+            {
+                using (var tx = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions
+                {
+                    IsolationLevel = IsolationLevel.ReadCommitted,
+                    Timeout = TimeSpan.FromSeconds(60)
+                }, TransactionScopeAsyncFlowOption.Enabled))
+                {
+                    await _bus.SendLocal("alles cavakes?");
+
+                    if (throwInsideTransactionScope)
+                    {
+                        throw new RebusApplicationException("the ting goes skraa");
+                    }
+
+                    if (completeTransaction)
+                    {
+                        tx.Complete();
+                    }
+                }
+            }
+            catch (RebusApplicationException) when (throwInsideTransactionScope)
+            {
+                // Intended
+            }
+
+            if (expectMessageReceived)
+            {
+                gotTheMessage.WaitOrDie(TimeSpan.FromSeconds(10));
+            }
+
+            await Task.Delay(500);
+
+            Assert.That(receivedMessageCount, Is.EqualTo(expectMessageReceived ? 1 : 0));
+        }
+    }
+}

--- a/Rebus.Oracle.Tests/OracleTestHelper.cs
+++ b/Rebus.Oracle.Tests/OracleTestHelper.cs
@@ -18,7 +18,7 @@ namespace Rebus.Oracle.Tests
 
         public static void DropTableAndSequence(string tableName)
         {
-            using (var connection = OracleConnectionHelper.GetConnection().Result)
+            using (var connection = OracleConnectionHelper.GetConnection())
             {
                 using (var comand = connection.CreateCommand())
                 {

--- a/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
+++ b/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Rebus.Oracle\Rebus.Oracle.csproj" />
     <PackageReference Include="nunit" Version="3.7.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="rebus" Version="4.2.1" />
     <PackageReference Include="rebus.tests.contracts" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />

--- a/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
+++ b/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus.Oracle.Tests</RootNamespace>
     <AssemblyName>Rebus.Oracle.Tests</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Rebus.Oracle.Tests/Sagas/OracleSnapshotStorageFactory.cs
+++ b/Rebus.Oracle.Tests/Sagas/OracleSnapshotStorageFactory.cs
@@ -27,7 +27,7 @@ namespace Rebus.Oracle.Tests.Sagas
 
         public IEnumerable<SagaDataSnapshot> GetAllSnapshots()
         {
-            using (var connection = OracleTestHelper.ConnectionHelper.GetConnection().Result)
+            using (var connection = OracleTestHelper.ConnectionHelper.GetConnection())
             {
                 using (var command = connection.CreateCommand())
                 {

--- a/Rebus.Oracle/Config/OracleConfigurationExtensions.cs
+++ b/Rebus.Oracle/Config/OracleConfigurationExtensions.cs
@@ -22,11 +22,11 @@ namespace Rebus.Config
         /// </summary>
         public static void StoreInOracle(this StandardConfigurer<ISagaSnapshotStorage> configurer,
             string connectionString, string tableName, bool automaticallyCreateTables = true, 
-            Action<OracleConnection> additionalConnectionSetup = null)
+            Action<OracleConnection> additionalConnectionSetup = null, bool enlistInAmbientTransaction = false)
         {
             configurer.Register(c =>
             {
-                var sagaStorage = new OracleSagaSnapshotStorage(new OracleConnectionHelper(connectionString, additionalConnectionSetup), tableName);
+                var sagaStorage = new OracleSagaSnapshotStorage(new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction), tableName);
 
                 if (automaticallyCreateTables)
                 {
@@ -42,12 +42,12 @@ namespace Rebus.Config
         /// </summary>
         public static void StoreInOracle(this StandardConfigurer<ISagaStorage> configurer,
             string connectionString, string dataTableName, string indexTableName,
-            bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null)
+            bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null, bool enlistInAmbientTransaction = false)
         {
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var sagaStorage = new OracleSqlSagaStorage(new OracleConnectionHelper(connectionString, additionalConnectionSetup), dataTableName, indexTableName, rebusLoggerFactory);
+                var sagaStorage = new OracleSqlSagaStorage(new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction), dataTableName, indexTableName, rebusLoggerFactory);
 
                 if (automaticallyCreateTables)
                 {
@@ -62,12 +62,13 @@ namespace Rebus.Config
         /// Configures Rebus to use Oracle to store timeouts.
         /// </summary>
         public static void StoreInOracle(this StandardConfigurer<ITimeoutManager> configurer, string connectionString, string tableName, 
-            bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null)
+            bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null,
+            bool enlistInAmbientTransaction = false)
         {
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var subscriptionStorage = new OracleTimeoutManager(new OracleConnectionHelper(connectionString, additionalConnectionSetup), tableName, rebusLoggerFactory);
+                var subscriptionStorage = new OracleTimeoutManager(new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction), tableName, rebusLoggerFactory);
 
                 if (automaticallyCreateTables)
                 {
@@ -84,12 +85,13 @@ namespace Rebus.Config
         /// default behavior.
         /// </summary>
         public static void StoreInOracle(this StandardConfigurer<ISubscriptionStorage> configurer,
-            string connectionString, string tableName, bool isCentralized = false, bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null)
+            string connectionString, string tableName, bool isCentralized = false, bool automaticallyCreateTables = true, Action<OracleConnection> additionalConnectionSetup = null,
+            bool enlistInAmbientTransaction = false)
         {
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var connectionHelper = new OracleConnectionHelper(connectionString, additionalConnectionSetup);
+                var connectionHelper = new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction);
                 var subscriptionStorage = new OracleSubscriptionStorage(
                     connectionHelper, tableName, isCentralized, rebusLoggerFactory);
 

--- a/Rebus.Oracle/Config/OracleTransportConfigurationExtensions.cs
+++ b/Rebus.Oracle/Config/OracleTransportConfigurationExtensions.cs
@@ -20,9 +20,9 @@ namespace Rebus.Config
         /// store messages, and the "queue" specified by <paramref name="inputQueueName"/> will be used when querying for messages.
         /// The message table will automatically be created if it does not exist.
         /// </summary>
-        public static void UseOracle(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionOrConnectionStringName, string tableName, string inputQueueName)
+        public static void UseOracle(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionOrConnectionStringName, string tableName, string inputQueueName, bool enlistInAmbientTransaction = false)
         {
-            Configure(configurer, loggerFactory => new OracleConnectionHelper(connectionStringOrConnectionOrConnectionStringName), tableName, inputQueueName);
+            Configure(configurer, loggerFactory => new OracleConnectionHelper(connectionStringOrConnectionOrConnectionStringName, enlistInAmbientTransaction), tableName, inputQueueName);
         }
 
         /// <summary>
@@ -30,9 +30,9 @@ namespace Rebus.Config
         /// The table specified by <paramref name="tableName"/> will be used to store messages.
         /// The message table will automatically be created if it does not exist.
         /// </summary>
-        public static void UseOracleAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionStringName, string tableName)
+        public static void UseOracleAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionStringName, string tableName, bool enlistInAmbientTransaction = false)
         {
-            Configure(configurer, loggerFactory => new OracleConnectionHelper(connectionStringOrConnectionStringName), tableName, null);
+            Configure(configurer, loggerFactory => new OracleConnectionHelper(connectionStringOrConnectionStringName, enlistInAmbientTransaction), tableName, null);
 
             OneWayClientBackdoor.ConfigureOneWayClient(configurer);
         }

--- a/Rebus.Oracle/Oracle/OracleConnectionHelper.cs
+++ b/Rebus.Oracle/Oracle/OracleConnectionHelper.cs
@@ -16,9 +16,20 @@ namespace Rebus.Oracle
         /// <summary>
         /// Constructs this thingie
         /// </summary>
+        /// <param name="connectionString">Connection string.</param>
         public OracleConnectionHelper(string connectionString)
         {
             _connectionString = connectionString;
+        }
+
+        /// <summary>
+        /// Constructs this thingie
+        /// </summary>
+        /// <param name="connectionString">Connection string.</param>
+        /// <param name="enlistInAmbientTransaction">If <c>true</c> the connection will be enlisted in the ambient transaction if it exists, else it will create an OracleTransaction and enlist in it</param>
+        public OracleConnectionHelper(string connectionString, bool enlistInAmbientTransaction) 
+            : this(connectionString, null, enlistInAmbientTransaction)
+        {
         }
 
         /// <summary>

--- a/Rebus.Oracle/Oracle/OracleConnectionHelper.cs
+++ b/Rebus.Oracle/Oracle/OracleConnectionHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Data;
-using System.Threading.Tasks;
 using Oracle.ManagedDataAccess.Client;
 
 namespace Rebus.Oracle
@@ -12,6 +11,7 @@ namespace Rebus.Oracle
     {
         readonly string _connectionString;
         private readonly Action<OracleConnection> _additionalConnectionSetupCallback;
+        private readonly bool _enlistInAmbientTransaction;
 
         /// <summary>
         /// Constructs this thingie
@@ -27,28 +27,76 @@ namespace Rebus.Oracle
         /// <param name="connectionString">Connection string.</param>
         /// <param name="additionalConnectionSetupCallback">Additional setup to be performed prior to opening each connection. 
         /// Useful for configuring client certificate authentication, as well as set up other callbacks.</param>
-        public OracleConnectionHelper(string connectionString, Action<OracleConnection> additionalConnectionSetupCallback)
+        /// <param name="enlistInAmbientTransaction">If <c>true</c> the connection will be enlisted in the ambient transaction if it exists, else it will create an OracleTransaction and enlist in it</param>
+        public OracleConnectionHelper(string connectionString, Action<OracleConnection> additionalConnectionSetupCallback, bool enlistInAmbientTransaction)
         {
             _connectionString = connectionString;
             _additionalConnectionSetupCallback = additionalConnectionSetupCallback;
+            _enlistInAmbientTransaction = enlistInAmbientTransaction;
         }
 
 
         /// <summary>
         /// Gets a fresh, open and ready-to-use connection wrapper
         /// </summary>
-        public async Task<OracleDbConnection> GetConnection()
+        public OracleDbConnection GetConnection()
+        {
+            OracleConnection connection = null;
+            OracleTransaction transaction = null;
+            try
+            {
+                if (!_enlistInAmbientTransaction)
+                {
+                    connection = CreateOracleConnectionSuppressingAPossibleAmbientTransaction();
+                    transaction = connection.BeginTransaction(IsolationLevel.ReadCommitted);
+                }
+                else
+                {
+                    connection = CreateOracleConnectionInAPossiblyAmbientTransaction();
+                }
+
+                return new OracleDbConnection(connection, transaction);
+            }
+            catch (Exception)
+            {
+                connection?.Dispose();
+                throw;
+            }
+        }
+
+        private OracleConnection CreateOracleConnectionInAPossiblyAmbientTransaction()
         {
             var connection = new OracleConnection(_connectionString);
-            
-            if (_additionalConnectionSetupCallback != null)
-                _additionalConnectionSetupCallback.Invoke(connection);
 
-            await connection.OpenAsync();
+            _additionalConnectionSetupCallback?.Invoke(connection);
 
-            var currentTransaction = connection.BeginTransaction(IsolationLevel.ReadCommitted);
+            // do not use Async here! it would cause the tx scope to be disposed on another thread than the one that created it
+            connection.Open();
 
-            return new OracleDbConnection(connection, currentTransaction);
+            var transaction = System.Transactions.Transaction.Current;
+            if (transaction != null)
+            {
+                connection.EnlistTransaction(transaction);
+            }
+
+            return connection;
+        }
+
+        private OracleConnection CreateOracleConnectionSuppressingAPossibleAmbientTransaction()
+        {
+            OracleConnection connection;
+
+            using (new System.Transactions.TransactionScope(System.Transactions.TransactionScopeOption.Suppress))
+            {
+                connection = new OracleConnection(_connectionString);
+
+                _additionalConnectionSetupCallback?.Invoke(connection);
+
+                // do not use Async here! it would cause the tx scope to be disposed on another thread than the one that created it
+                connection.Open();
+            }
+
+            return connection;
         }
     }
 }

--- a/Rebus.Oracle/Oracle/OracleDbConnection.cs
+++ b/Rebus.Oracle/Oracle/OracleDbConnection.cs
@@ -23,7 +23,7 @@ namespace Rebus.Oracle
         public OracleDbConnection(OracleConnection currentConnection, OracleTransaction currentTransaction)
         {
             _currentConnection = currentConnection ?? throw new ArgumentNullException(nameof(currentConnection));
-            _currentTransaction = currentTransaction ?? throw new ArgumentNullException(nameof(currentTransaction));
+            _currentTransaction = currentTransaction;
         }
 
         /// <summary>

--- a/Rebus.Oracle/Oracle/Sagas/OracleSagaSnapshotStorage.cs
+++ b/Rebus.Oracle/Oracle/Sagas/OracleSagaSnapshotStorage.cs
@@ -33,7 +33,7 @@ namespace Rebus.Oracle.Sagas
         /// </summary>
         public async Task Save(ISagaData sagaData, Dictionary<string, string> sagaAuditMetadata)
         {
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             {
                 using (var command = connection.CreateCommand())
                 {
@@ -62,7 +62,7 @@ namespace Rebus.Oracle.Sagas
         /// </summary>
         public void EnsureTableIsCreated()
         {
-            using (var connection = _connectionHelper.GetConnection().Result)
+            using (var connection = _connectionHelper.GetConnection())
             {
                 var tableNames = connection.GetTableNames().ToHashSet();
 

--- a/Rebus.Oracle/Oracle/Sagas/OracleSqlSagaStorage.cs
+++ b/Rebus.Oracle/Oracle/Sagas/OracleSqlSagaStorage.cs
@@ -47,7 +47,7 @@ namespace Rebus.Oracle.Sagas
         /// </summary>
         public void EnsureTablesAreCreated()
         {
-            using (var connection = _connectionHelper.GetConnection().Result)
+            using (var connection = _connectionHelper.GetConnection())
             {
                 var tableNames = connection.GetTableNames().ToHashSet();
 
@@ -117,7 +117,7 @@ namespace Rebus.Oracle.Sagas
         /// </summary>
         public async Task<ISagaData> Find(Type sagaDataType, string propertyName, object propertyValue)
         {
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             {
                 using (var command = connection.CreateCommand())
                 {
@@ -145,8 +145,7 @@ namespace Rebus.Oracle.Sagas
                         command.Parameters.Add(new OracleParameter("value", OracleDbType.NVarchar2, (propertyValue ?? "").ToString(), ParameterDirection.Input));
                     }
 
-                    var data = (byte[]) command.ExecuteScalar();
-                    //var data = command.ExecuteScalar();
+                    var data = (byte[]) await command.ExecuteScalarAsync();
 
                     if (data == null) return null;
 
@@ -199,7 +198,7 @@ namespace Rebus.Oracle.Sagas
                     $"Attempted to insert saga data with ID {sagaData.Id} and revision {sagaData.Revision}, but revision must be 0 on first insert!");
             }
 
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             {
                 using (var command = connection.CreateCommand())
                 {
@@ -217,7 +216,7 @@ namespace Rebus.Oracle.Sagas
 
                     try
                     {
-                        command.ExecuteNonQuery();
+                        await command.ExecuteNonQueryAsync();
                     }
                     catch (OracleException exception)
                     {
@@ -244,7 +243,7 @@ namespace Rebus.Oracle.Sagas
         /// </summary>
         public async Task Update(ISagaData sagaData, IEnumerable<ISagaCorrelationProperty> correlationProperties)
         {
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             {
                 var revisionToUpdate = sagaData.Revision;
 
@@ -302,7 +301,7 @@ namespace Rebus.Oracle.Sagas
         /// </summary>
         public async Task Delete(ISagaData sagaData)
         {
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             {
                 using (var command = connection.CreateCommand())
                 {

--- a/Rebus.Oracle/Oracle/Timeouts/OracleTimeoutManager.cs
+++ b/Rebus.Oracle/Oracle/Timeouts/OracleTimeoutManager.cs
@@ -43,7 +43,7 @@ namespace Rebus.Oracle.Timeouts
         /// </summary>
         public async Task Defer(DateTimeOffset approximateDueTime, Dictionary<string, string> headers, byte[] body)
         {
-            using (var connection = await _connectionHelper.GetConnection())
+            using (var connection = _connectionHelper.GetConnection())
             {
                 using (var command = connection.CreateCommand())
                 {
@@ -65,7 +65,7 @@ namespace Rebus.Oracle.Timeouts
         /// </summary>
         public async Task<DueMessagesResult> GetDueMessages()
         {
-            var connection = await _connectionHelper.GetConnection();
+            var connection = _connectionHelper.GetConnection();
 
             try
             {
@@ -129,7 +129,7 @@ namespace Rebus.Oracle.Timeouts
         /// </summary>
         public void EnsureTableIsCreated()
         {
-            using (var connection = _connectionHelper.GetConnection().Result)
+            using (var connection = _connectionHelper.GetConnection())
             {
                 var tableNames = connection.GetTableNames();
 

--- a/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
+++ b/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
@@ -204,7 +204,7 @@ namespace Rebus.Oracle.Transport
 
             while (true)
             {
-                using (var connection = await _connectionHelper.GetConnection())
+                using (var connection = _connectionHelper.GetConnection())
                 {
                     int affectedRows;
 
@@ -258,7 +258,7 @@ namespace Rebus.Oracle.Transport
 
         void CreateSchema()
         {
-            using (var connection = _connectionHelper.GetConnection().Result)
+            using (var connection = _connectionHelper.GetConnection())
             {
                 var tableNames = connection.GetTableNames();
 
@@ -378,7 +378,8 @@ END;
                 .GetOrAdd(CurrentConnectionKey,
                     async () =>
                     {
-                        var dbConnection = await _connectionHelper.GetConnection();
+                        await Task.CompletedTask;
+                        var dbConnection = _connectionHelper.GetConnection();
                         var connectionWrapper = new ConnectionWrapper(dbConnection);
                         context.OnCommitted(() =>
                         {

--- a/Rebus.Oracle/Rebus.Oracle.csproj
+++ b/Rebus.Oracle/Rebus.Oracle.csproj
@@ -46,7 +46,6 @@
 
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <Reference Include="System.Data.Common" />
     <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">


### PR DESCRIPTION
Adds support for enlisting in an ambient transaction. Fixes issue #7.

Implementation is backwards compatible and similar to [pull request 27](https://github.com/rebus-org/Rebus.SqlServer/pull/27) in `Rebus.SqlServer`.