### PR TITLE
Added .editorconfig file + whitespace fixing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+
+[*.csproj]
+indent_style = space
+indent_size = 2

--- a/Rebus.Oracle.Devart/Oracle/Sagas/OracleSqlSagaStorage.cs
+++ b/Rebus.Oracle.Devart/Oracle/Sagas/OracleSqlSagaStorage.cs
@@ -137,7 +137,7 @@ namespace Rebus.Oracle.Sagas
                             SELECT s.data
                                 FROM {_dataTableName} s
                                 JOIN {_indexTableName} i on s.id = i.saga_id 
-                                WHERE i.saga_type = :saga_type AND  i.key = :key AND i.value = :value
+                                WHERE i.saga_type = :saga_type AND i.key = :key AND i.value = :value
                             ";
                         command.Parameters.Add(new OracleParameter("key", OracleDbType.NVarChar, propertyName, ParameterDirection.Input));
                         command.Parameters.Add(new OracleParameter("saga_type", OracleDbType.NVarChar, GetSagaTypeName(sagaDataType), ParameterDirection.Input));
@@ -358,7 +358,7 @@ namespace Rebus.Oracle.Sagas
             {
                 // generate batch insert with SQL for each entry in the index
                 command.CommandText =
-                    $@"INSERT INTO {_indexTableName} (saga_type, key, value, saga_id)  VALUES (:saga_type, :key, :value, :saga_id)";
+                    $@"INSERT INTO {_indexTableName} (saga_type, key, value, saga_id) VALUES (:saga_type, :key, :value, :saga_id)";
                 command.Parameters.Add(new OracleParameter("saga_type", OracleDbType.NVarChar, parameters.Select(x => x.SagaType).ToArray(), ParameterDirection.Input));
                 command.Parameters.Add(new OracleParameter("key", OracleDbType.NVarChar, parameters.Select(x => x.PropertyName).ToArray(), ParameterDirection.Input));
                 command.Parameters.Add(new OracleParameter("value", OracleDbType.NVarChar, parameters.Select(x => x.PropertyValue).ToArray(), ParameterDirection.Input));

--- a/Rebus.Oracle.Devart/Oracle/Subscriptions/OracleSubscriptionStorage.cs
+++ b/Rebus.Oracle.Devart/Oracle/Subscriptions/OracleSubscriptionStorage.cs
@@ -54,9 +54,9 @@ namespace Rebus.Oracle.Subscriptions
                     command.CommandText =
                         $@"
 CREATE TABLE {_tableName} (
-	topic VARCHAR(200) NOT NULL,
-	address VARCHAR(200) NOT NULL,
-	PRIMARY KEY (topic,address)
+    topic VARCHAR(200) NOT NULL,
+    address VARCHAR(200) NOT NULL,
+    PRIMARY KEY (topic,address)
 )";
                     command.ExecuteNonQuery();
                 }

--- a/Rebus.Oracle.Devart/Oracle/Timeouts/OracleTimeoutManager.cs
+++ b/Rebus.Oracle.Devart/Oracle/Timeouts/OracleTimeoutManager.cs
@@ -141,10 +141,10 @@ namespace Rebus.Oracle.Timeouts
                     command.CommandText =
                         $@"
                         CREATE TABLE {_tableName} (
-                            id  NUMBER(10) NOT NULL,
+                            id NUMBER(10) NOT NULL,
                             due_time TIMESTAMP(7) WITH TIME ZONE NOT NULL,
                             headers CLOB,
-                            body  BLOB,
+                            body BLOB,
                             CONSTRAINT {_tableName}_pk PRIMARY KEY(id)
                          )";
 
@@ -162,7 +162,7 @@ namespace Rebus.Oracle.Timeouts
                     command.CommandText =
                         $@"
                         CREATE OR REPLACE TRIGGER {_tableName}_on_insert
-                             BEFORE INSERT ON  {_tableName}
+                             BEFORE INSERT ON {_tableName}
                              FOR EACH ROW
                         BEGIN
                             if :new.Id is null then

--- a/Rebus.Oracle.Devart/Oracle/Transport/OracleTransport.cs
+++ b/Rebus.Oracle.Devart/Oracle/Transport/OracleTransport.cs
@@ -270,13 +270,13 @@ namespace Rebus.Oracle.Transport
                 ExecuteCommands(connection, $@"
 CREATE TABLE {_tableName}
 (
-	id NUMBER(20) NOT NULL,
-	recipient VARCHAR2(255) NOT NULL,
-	priority NUMBER(20) NOT NULL,
+    id NUMBER(20) NOT NULL,
+    recipient VARCHAR2(255) NOT NULL,
+    priority NUMBER(20) NOT NULL,
     expiration timestamp(7) with time zone NOT NULL,
     visible timestamp(7) with time zone NOT NULL,
-	headers blob NOT NULL,
-	body blob NOT NULL
+    headers blob NOT NULL,
+    body blob NOT NULL
 )
 ----
 ALTER TABLE {_tableName} ADD CONSTRAINT {_tableName}_pk PRIMARY KEY(recipient, priority, id)
@@ -284,7 +284,7 @@ ALTER TABLE {_tableName} ADD CONSTRAINT {_tableName}_pk PRIMARY KEY(recipient, p
 CREATE SEQUENCE {_tableName}_SEQ
 ----
 CREATE OR REPLACE TRIGGER {_tableName}_on_insert
-     BEFORE INSERT ON  {_tableName}
+     BEFORE INSERT ON {_tableName}
      FOR EACH ROW
 BEGIN
     if :new.Id is null then
@@ -294,12 +294,12 @@ END;
 ----
 CREATE INDEX idx_receive_{_tableName} ON {_tableName}
 (
-	recipient ASC,
+    recipient ASC,
     expiration ASC,
     visible ASC
 )
 ----
-create or replace PROCEDURE  rebus_dequeue_{_tableName}(recipientQueue IN varchar, output OUT SYS_REFCURSOR ) AS
+create or replace PROCEDURE rebus_dequeue_{_tableName}(recipientQueue IN varchar, output OUT SYS_REFCURSOR ) AS
   messageId number;
   readCursor SYS_REFCURSOR; 
 begin
@@ -316,7 +316,7 @@ begin
     fetch readCursor into messageId;
     close readCursor;      
   open output for select * from {_tableName} where id = messageId;
-  delete from {_tableName} where  id = messageId;
+  delete from {_tableName} where id = messageId;
 END;
 ");
 

--- a/Rebus.Oracle/Oracle/Sagas/OracleSqlSagaStorage.cs
+++ b/Rebus.Oracle/Oracle/Sagas/OracleSqlSagaStorage.cs
@@ -137,7 +137,7 @@ namespace Rebus.Oracle.Sagas
                             SELECT s.data
                                 FROM {_dataTableName} s
                                 JOIN {_indexTableName} i on s.id = i.saga_id 
-                                WHERE i.saga_type = :saga_type AND  i.key = :key AND i.value = :value
+                                WHERE i.saga_type = :saga_type AND i.key = :key AND i.value = :value
                             ";
                         command.BindByName = true;
                         command.Parameters.Add(new OracleParameter("key", OracleDbType.NVarchar2, propertyName, ParameterDirection.Input));
@@ -363,7 +363,7 @@ namespace Rebus.Oracle.Sagas
             {
                 // generate batch insert with SQL for each entry in the index
                 command.CommandText =
-                    $@"INSERT INTO {_indexTableName} (saga_type, key, value, saga_id)  VALUES (:saga_type, :key, :value, :saga_id)";
+                    $@"INSERT INTO {_indexTableName} (saga_type, key, value, saga_id) VALUES (:saga_type, :key, :value, :saga_id)";
                 command.BindByName = true;
                 command.ArrayBindCount = parameters.Count;
                 command.Parameters.Add(new OracleParameter("saga_type", OracleDbType.NVarchar2, parameters.Select(x => x.SagaType).ToArray(), ParameterDirection.Input));

--- a/Rebus.Oracle/Oracle/Subscriptions/OracleSubscriptionStorage.cs
+++ b/Rebus.Oracle/Oracle/Subscriptions/OracleSubscriptionStorage.cs
@@ -52,9 +52,9 @@ namespace Rebus.Oracle.Subscriptions
                     command.CommandText =
                         $@"
 CREATE TABLE {_tableName} (
-	topic VARCHAR(200) NOT NULL,
-	address VARCHAR(200) NOT NULL,
-	PRIMARY KEY (topic,address)
+    topic VARCHAR(200) NOT NULL,
+    address VARCHAR(200) NOT NULL,
+    PRIMARY KEY (topic,address)
 )";
                     command.ExecuteNonQuery();
                 }

--- a/Rebus.Oracle/Oracle/Timeouts/OracleTimeoutManager.cs
+++ b/Rebus.Oracle/Oracle/Timeouts/OracleTimeoutManager.cs
@@ -144,10 +144,10 @@ namespace Rebus.Oracle.Timeouts
                     command.CommandText =
                         $@"
                         CREATE TABLE {_tableName} (
-                            id  NUMBER(10) NOT NULL,
+                            id NUMBER(10) NOT NULL,
                             due_time TIMESTAMP(7) WITH TIME ZONE NOT NULL,
                             headers CLOB,
-                            body  BLOB,
+                            body BLOB,
                             CONSTRAINT {_tableName}_pk PRIMARY KEY(id)
                          )";
 
@@ -165,7 +165,7 @@ namespace Rebus.Oracle.Timeouts
                     command.CommandText =
                         $@"
                         CREATE OR REPLACE TRIGGER {_tableName}_on_insert
-                             BEFORE INSERT ON  {_tableName}
+                             BEFORE INSERT ON {_tableName}
                              FOR EACH ROW
                         BEGIN
                             if :new.Id is null then

--- a/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
+++ b/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
@@ -273,13 +273,13 @@ namespace Rebus.Oracle.Transport
                 ExecuteCommands(connection, $@"
 CREATE TABLE {_tableName}
 (
-	id NUMBER(20) NOT NULL,
-	recipient VARCHAR2(255) NOT NULL,
-	priority NUMBER(20) NOT NULL,
+    id NUMBER(20) NOT NULL,
+    recipient VARCHAR2(255) NOT NULL,
+    priority NUMBER(20) NOT NULL,
     expiration timestamp(7) with time zone NOT NULL,
     visible timestamp(7) with time zone NOT NULL,
-	headers blob NOT NULL,
-	body blob NOT NULL
+    headers blob NOT NULL,
+    body blob NOT NULL
 )
 ----
 ALTER TABLE {_tableName} ADD CONSTRAINT {_tableName}_pk PRIMARY KEY(recipient, priority, id)
@@ -287,7 +287,7 @@ ALTER TABLE {_tableName} ADD CONSTRAINT {_tableName}_pk PRIMARY KEY(recipient, p
 CREATE SEQUENCE {_tableName}_SEQ
 ----
 CREATE OR REPLACE TRIGGER {_tableName}_on_insert
-     BEFORE INSERT ON  {_tableName}
+     BEFORE INSERT ON {_tableName}
      FOR EACH ROW
 BEGIN
     if :new.Id is null then
@@ -297,12 +297,12 @@ END;
 ----
 CREATE INDEX idx_receive_{_tableName} ON {_tableName}
 (
-	recipient ASC,
+    recipient ASC,
     expiration ASC,
     visible ASC
 )
 ----
-create or replace PROCEDURE  rebus_dequeue_{_tableName}(recipientQueue IN varchar, output OUT SYS_REFCURSOR ) AS
+create or replace PROCEDURE rebus_dequeue_{_tableName}(recipientQueue IN varchar, output OUT SYS_REFCURSOR ) AS
   messageId number;
   readCursor SYS_REFCURSOR; 
 begin
@@ -319,7 +319,7 @@ begin
     fetch readCursor into messageId;
     close readCursor;      
   open output for select * from {_tableName} where id = messageId;
-  delete from {_tableName} where  id = messageId;
+  delete from {_tableName} where id = messageId;
 END;
 ");
 

--- a/Rebus.Oracle/Rebus.Oracle.csproj
+++ b/Rebus.Oracle/Rebus.Oracle.csproj
@@ -42,8 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.12.0-beta3" />
-        <PackageReference Include="Rebus" Version="4.2.1" />
-
+    <PackageReference Include="Rebus" Version="4.2.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />


### PR DESCRIPTION
This PR only contains trivial, cosmetic changes.

I noticed some SQL was poorly laid out because of tabs being used instead of 4 spaces, so I added an `.editorconfig` file. 
This makes it easy for every contributor to use the proper indentation no matter how they usually configure their editor.

I went ahead and fixed whitespaces inconsistencies.