### PR TITLE
Don't use async Oracle methods

### DIFF
--- a/Rebus.Oracle/Oracle/Sagas/OracleSagaSnapshotStorage.cs
+++ b/Rebus.Oracle/Oracle/Sagas/OracleSagaSnapshotStorage.cs
@@ -31,7 +31,7 @@ namespace Rebus.Oracle.Sagas
         /// <summary>
         /// Saves the <paramref name="sagaData"/> snapshot and the accompanying <paramref name="sagaAuditMetadata"/>
         /// </summary>
-        public async Task Save(ISagaData sagaData, Dictionary<string, string> sagaAuditMetadata)
+        public Task Save(ISagaData sagaData, Dictionary<string, string> sagaAuditMetadata)
         {
             using (var connection = _connectionHelper.GetConnection())
             {
@@ -47,13 +47,14 @@ namespace Rebus.Oracle.Sagas
                     command.Parameters.Add("id", OracleDbType.Raw).Value = sagaData.Id;
                     command.Parameters.Add("revision", OracleDbType.Int64).Value = sagaData.Revision;
                     command.Parameters.Add("data", OracleDbType.Blob).Value = _objectSerializer.Serialize(sagaData);
-                    command.Parameters.Add("metadata", OracleDbType.Clob).Value =
-                    _dictionarySerializer.SerializeToString(sagaAuditMetadata);
+                    command.Parameters.Add("metadata", OracleDbType.Clob).Value = 
+                        _dictionarySerializer.SerializeToString(sagaAuditMetadata);
 
-                    await command.ExecuteNonQueryAsync();
+                    command.ExecuteNonQuery();
                 }
                 
                 connection.Complete();
+                return Task.CompletedTask;
             }
         }
 

--- a/Rebus.Oracle/Oracle/Subscriptions/OracleSubscriptionStorage.cs
+++ b/Rebus.Oracle/Oracle/Subscriptions/OracleSubscriptionStorage.cs
@@ -66,7 +66,7 @@ CREATE TABLE {_tableName} (
         /// <summary>
         /// Gets all destination addresses for the given topic
         /// </summary>
-        public async Task<string[]> GetSubscriberAddresses(string topic)
+        public Task<string[]> GetSubscriberAddresses(string topic)
         {
             using (var connection = _connectionHelper.GetConnection())
             using (var command = connection.CreateCommand())
@@ -78,7 +78,7 @@ CREATE TABLE {_tableName} (
 
                 var endpoints = new List<string>();
 
-                using (var reader = await command.ExecuteReaderAsync())
+                using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())
                     {
@@ -86,14 +86,14 @@ CREATE TABLE {_tableName} (
                     }
                 }
 
-                return endpoints.ToArray();
+                return Task.FromResult(endpoints.ToArray());
             }
         }
 
         /// <summary>
         /// Registers the given <paramref name="subscriberAddress" /> as a subscriber of the given topic
         /// </summary>
-        public async Task RegisterSubscriber(string topic, string subscriberAddress)
+        public Task RegisterSubscriber(string topic, string subscriberAddress)
         {
             using (var connection = _connectionHelper.GetConnection())
             using (var command = connection.CreateCommand())
@@ -107,7 +107,7 @@ CREATE TABLE {_tableName} (
 
                 try
                 {
-                    await command.ExecuteNonQueryAsync();
+                    command.ExecuteNonQuery();
                 }
                 catch (OracleException exception) when (exception.Number == UniqueKeyViolation)
                 {
@@ -115,15 +115,15 @@ CREATE TABLE {_tableName} (
                 }
 
                 connection.Complete();
+                return Task.CompletedTask;
             }
         }
 
         /// <summary>
         /// Unregisters the given <paramref name="subscriberAddress" /> as a subscriber of the given topic
         /// </summary>
-        public async Task UnregisterSubscriber(string topic, string subscriberAddress)
+        public Task UnregisterSubscriber(string topic, string subscriberAddress)
         {
-            await Task.CompletedTask;
             using (var connection = _connectionHelper.GetConnection())
             using (var command = connection.CreateCommand())
             {
@@ -136,7 +136,7 @@ CREATE TABLE {_tableName} (
 
                 try
                 {
-                    await command.ExecuteNonQueryAsync();
+                    command.ExecuteNonQuery();
                 }
                 catch (OracleException exception)
                 {
@@ -144,6 +144,7 @@ CREATE TABLE {_tableName} (
                 }
 
                 connection.Complete();
+                return Task.CompletedTask;
             }
         }
 

--- a/Rebus.Oracle/Rebus.Oracle.csproj
+++ b/Rebus.Oracle/Rebus.Oracle.csproj
@@ -45,9 +45,6 @@
         <PackageReference Include="Rebus" Version="4.2.1" />
 
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
-  </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />
   </Target>


### PR DESCRIPTION
> ⚠️ **Tests not run yet** (no access to an Oracle DB atm)

They are not implemented and fallback to wrapping sync ones.

Using async calls with Oracle.ManagedDataAccess only results in more allocations (tasks, async state machines, etc) and more complex code; yet yields no benefit since they all block and complete synchronously.

This change enabled me to get rid of a reference to SQL Server assembly, which is not desirable in this project.

Fixes #12 