### PR TITLE
Add DataBus storage

### DIFF
--- a/Rebus.Oracle.Tests/DataBus/OracleDataBusStorageFactory.cs
+++ b/Rebus.Oracle.Tests/DataBus/OracleDataBusStorageFactory.cs
@@ -1,0 +1,28 @@
+using System;
+using Rebus.DataBus;
+using Rebus.Logging;
+using Rebus.Oracle.DataBus;
+using Rebus.Tests.Contracts.DataBus;
+
+namespace Rebus.Oracle.Tests.DataBus
+{
+    public class OracleDataBusStorageFactory : IDataBusStorageFactory
+    {        
+        readonly FakeRebusTime _fakeRebusTime = new FakeRebusTime();
+        
+        public IDataBusStorage Create()
+        {
+            var consoleLoggerFactory = new ConsoleLoggerFactory(false);
+            var sqlServerDataBusStorage = new OracleDataBusStorage(OracleTestHelper.ConnectionHelper, "databus", true, consoleLoggerFactory, _fakeRebusTime);
+            sqlServerDataBusStorage.Initialize();
+            return sqlServerDataBusStorage;
+        }
+
+        public void CleanUp()
+        {
+            OracleTestHelper.DropTable("databus");
+        }
+
+        public void FakeIt(DateTimeOffset fakeTime) => _fakeRebusTime.SetNow(fakeTime);
+    }
+}

--- a/Rebus.Oracle.Tests/DataBus/OracleDataBusStorageTest.cs
+++ b/Rebus.Oracle.Tests/DataBus/OracleDataBusStorageTest.cs
@@ -1,0 +1,8 @@
+using NUnit.Framework;
+using Rebus.Tests.Contracts.DataBus;
+
+namespace Rebus.Oracle.Tests.DataBus
+{
+    [TestFixture]
+    public class SqlServerDataBusStorageTest : GeneralDataBusStorageTests<OracleDataBusStorageFactory> { }
+}

--- a/Rebus.Oracle.Tests/DataBus/TestOracleDataBusLazyRead.cs
+++ b/Rebus.Oracle.Tests/DataBus/TestOracleDataBusLazyRead.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.DataBus;
+using Rebus.Tests.Contracts;
+
+namespace Rebus.Oracle.Tests.DataBus
+{
+    [TestFixture]
+    public class TestSqlServerDataBusLazyRead : FixtureBase
+    {
+        IDataBusStorage _storage;
+        OracleDataBusStorageFactory _factory;
+
+        protected override void SetUp()
+        {
+            _factory = new OracleDataBusStorageFactory();
+            _storage = _factory.Create();
+        }
+
+        protected override void TearDown()
+        {
+            _factory.CleanUp();
+        }
+
+        [TestCase(1024*1024*100)]
+        public async Task ReadingIsLazy(int byteCount)
+        {
+            const string dataId = "known id";
+
+            Console.WriteLine($"Generating {byteCount/(double)(1024*1024):0.00} MB of data...");
+
+            var data = GenerateData(byteCount);
+
+            Console.WriteLine("Saving data...");
+
+            await _storage.Save(dataId, new MemoryStream(data));
+
+            Console.WriteLine("Reading data...");
+
+            var stopwatch = Stopwatch.StartNew();
+            using (var source = await _storage.Read(dataId))
+            using (var destination = new MemoryStream())
+            {
+                var elapsedWhenStreamIsOpen = stopwatch.Elapsed;
+
+                Console.WriteLine($"Opening stream took {elapsedWhenStreamIsOpen.TotalSeconds:0.00} s");
+
+                await source.CopyToAsync(destination);
+
+                var elapsedWhenStreamHasBeenRead = stopwatch.Elapsed;
+
+                Console.WriteLine($"Entire operation took {elapsedWhenStreamHasBeenRead.TotalSeconds:0.00} s");
+
+                var fraction = elapsedWhenStreamHasBeenRead.TotalSeconds/10;
+                Assert.That(elapsedWhenStreamIsOpen.TotalSeconds, Is.LessThan(fraction), 
+                    "Expected time to open stream to be less than 1/10 of the time it takes to read the entire stream");
+            }
+        }
+
+        static byte[] GenerateData(int byteCount)
+        {
+            var buffer = new byte[byteCount];
+            new Random(DateTime.Now.GetHashCode()).NextBytes(buffer);
+            return buffer;
+        }
+    }
+}

--- a/Rebus.Oracle.Tests/DataBus/TestOracleDataBusStorage.cs
+++ b/Rebus.Oracle.Tests/DataBus/TestOracleDataBusStorage.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Logging;
+using Rebus.Oracle.DataBus;
+using Rebus.Tests.Contracts;
+using Rebus.Tests.Contracts.Extensions;
+
+namespace Rebus.Oracle.Tests.DataBus
+{
+    [TestFixture]
+    public class TestSqlServerDataBusStorage : FixtureBase
+    {
+        OracleDataBusStorage _storage;
+
+        protected override void SetUp()
+        {
+            var loggerFactory = new ConsoleLoggerFactory(false);
+            var tableName = TestConfig.GetName("data");
+
+            OracleTestHelper.DropTable(tableName);
+
+            _storage = new OracleDataBusStorage(OracleTestHelper.ConnectionHelper, tableName, true, loggerFactory, new FakeRebusTime());
+            _storage.Initialize();
+        }
+
+        [Test]
+        public async Task CanReadDataInParallel()
+        {
+            var longString = string.Concat(Enumerable.Repeat(@"
+Let me explain something to you. Um, I am not ""Mr.Lebowski"". 
+You're Mr. Lebowski. I'm the Dude. 
+So that's what you call me. 
+You know, that or, uh, His Dudeness, or uh, Duder, or El Duderino if you're not into the whole brevity thing.
+", 100));
+
+            const string dataId = "known-id";
+
+            using (var source = new MemoryStream(Encoding.UTF8.GetBytes(longString)))
+            {
+                await _storage.Save(dataId, source);
+            }
+
+            var caughtExceptions = new ConcurrentQueue<Exception>();
+
+            Console.WriteLine("Reading the data many times in parallel");
+            var threads = Enumerable.Range(0, 10)
+                .Select(i =>
+                {
+                    var thread = new Thread(() =>
+                    {
+                        100.Times(() =>
+                        {
+                            Console.Write(".");
+                            try
+                            {
+                                using (var source = _storage.Read(dataId).Result)
+                                using (var destination = new MemoryStream())
+                                {
+                                    source.CopyTo(destination);
+                                }
+                            }
+                            catch (Exception exception)
+                            {
+                                caughtExceptions.Enqueue(exception);
+                            }
+                        });
+                    });
+
+                    return thread;
+                })
+                .ToList();
+
+            Console.WriteLine("Starting threads");
+            threads.ForEach(t => t.Start());
+
+            Console.WriteLine("Waiting for them to finish");
+            threads.ForEach(t => t.Join());
+
+            Console.WriteLine("Finished :)");
+
+            if (caughtExceptions.Count > 0)
+            {
+                Assert.Fail($@"Caught {caughtExceptions.Count} exceptions - here's the first 5:
+{string.Join(Environment.NewLine + Environment.NewLine, caughtExceptions.Take(5))}");
+            }
+
+        }
+    }
+}

--- a/Rebus.Oracle.Tests/DataBus/TestOracleDataBusStorage.cs
+++ b/Rebus.Oracle.Tests/DataBus/TestOracleDataBusStorage.cs
@@ -16,17 +16,19 @@ namespace Rebus.Oracle.Tests.DataBus
     [TestFixture]
     public class TestSqlServerDataBusStorage : FixtureBase
     {
+        readonly string tableName = TestConfig.GetName("data");
         OracleDataBusStorage _storage;
 
         protected override void SetUp()
         {
             var loggerFactory = new ConsoleLoggerFactory(false);
-            var tableName = TestConfig.GetName("data");
-
-            OracleTestHelper.DropTable(tableName);
-
             _storage = new OracleDataBusStorage(OracleTestHelper.ConnectionHelper, tableName, true, loggerFactory, new FakeRebusTime());
             _storage.Initialize();
+        }
+
+        protected override void TearDown()
+        {
+            OracleTestHelper.DropTable(tableName);
         }
 
         [Test]
@@ -40,8 +42,10 @@ You know, that or, uh, His Dudeness, or uh, Duder, or El Duderino if you're not 
 ", 100));
 
             const string dataId = "known-id";
+            var bytes = Encoding.UTF8.GetBytes(longString);
+            int length = bytes.Length;
 
-            using (var source = new MemoryStream(Encoding.UTF8.GetBytes(longString)))
+            using (var source = new MemoryStream(bytes))
             {
                 await _storage.Save(dataId, source);
             }
@@ -63,6 +67,7 @@ You know, that or, uh, His Dudeness, or uh, Duder, or El Duderino if you're not 
                                 using (var destination = new MemoryStream())
                                 {
                                     source.CopyTo(destination);
+                                    Assert.AreEqual(length, destination.Length);
                                 }
                             }
                             catch (Exception exception)

--- a/Rebus.Oracle.Tests/FakeRebusTime.cs
+++ b/Rebus.Oracle.Tests/FakeRebusTime.cs
@@ -1,0 +1,14 @@
+using System;
+using Rebus.Time;
+
+namespace Rebus.Oracle.Tests
+{
+    class FakeRebusTime : IRebusTime
+    {
+        Func<DateTimeOffset> _nowFactory = () => DateTimeOffset.Now;
+
+        public DateTimeOffset Now => _nowFactory();
+
+        public void SetNow(DateTimeOffset fakeTime) => _nowFactory = () => fakeTime;
+    }
+}

--- a/Rebus.Oracle.Tests/Integration/TestOracleAllTheWay.cs
+++ b/Rebus.Oracle.Tests/Integration/TestOracleAllTheWay.cs
@@ -22,8 +22,6 @@ namespace Rebus.Oracle.Tests.Integration
 
         protected override void SetUp()
         {
-            DropTables();
-
             _activator = new BuiltinHandlerActivator();
 
             Using(_activator);
@@ -40,12 +38,8 @@ namespace Rebus.Oracle.Tests.Integration
 
         protected override void TearDown()
         {
-            DropTables();
-        }
-
-        static void DropTables()
-        {
             OracleTestHelper.DropTableAndSequence("transports");
+            OracleTestHelper.DropProcedure("rebus_dequeue_transports");
         }
 
         [Test]

--- a/Rebus.Oracle.Tests/OracleTestHelper.cs
+++ b/Rebus.Oracle.Tests/OracleTestHelper.cs
@@ -16,44 +16,35 @@ namespace Rebus.Oracle.Tests
 
         public static OracleConnectionHelper ConnectionHelper => OracleConnectionHelper;
 
-        public static void DropTableAndSequence(string tableName)
+        static void DropTable(string tableName, bool dropSequence)
         {
             using (var connection = OracleConnectionHelper.GetConnection())
+            using (var command = connection.CreateCommand())
             {
-                using (var comand = connection.CreateCommand())
+                try
                 {
-                    comand.CommandText = $@"drop table {tableName}";
-
-                    try
-                    {
-                        comand.ExecuteNonQuery();
-
-                        Console.WriteLine("Dropped oracle table '{0}'", tableName);
-                    }
-                    catch (OracleException exception) when (exception.Number == TableDoesNotExist)
-                    {
-                    }
+                    command.CommandText = "drop table " + tableName;
+                    command.ExecuteNonQuery();
+                    Console.WriteLine($"Dropped oracle table '{tableName}'");                    
                 }
-
-                using (var comand = connection.CreateCommand())
+                catch (OracleException exception) when (exception.Number == TableDoesNotExist)
+                { }
+                
+                try
                 {
-                    comand.CommandText = $@"drop sequence {tableName}_SEQ";
-
-                    try
-                    {
-                        comand.ExecuteNonQuery();
-
-                        Console.WriteLine("Dropped oracle sequence '{0}_SEQ'", tableName);
-                    }
-                    catch (OracleException exception) when (exception.Number ==SequenceDoesNotExist)
-                    {
-                    }
+                    command.CommandText = $"drop sequence {tableName}_SEQ";
+                    command.ExecuteNonQuery();
+                    Console.WriteLine("Dropped oracle sequence '{0}_SEQ'", tableName);
                 }
-
+                catch (OracleException exception) when (exception.Number == SequenceDoesNotExist)
+                { }
 
                 connection.Complete();
             }
         }
+
+        public static void DropTable(string tableName) => DropTable(tableName, dropSequence: false);
+        public static void DropTableAndSequence(string tableName) => DropTable(tableName, dropSequence: true);
 
         static string GetConnectionStringForDatabase(string databaseName)
         {

--- a/Rebus.Oracle.Tests/OracleTestHelper.cs
+++ b/Rebus.Oracle.Tests/OracleTestHelper.cs
@@ -8,6 +8,7 @@ namespace Rebus.Oracle.Tests
     {
         const int TableDoesNotExist = 942;
         const int SequenceDoesNotExist = 2289;
+        const int ProcedureDoesNotExist = 4043;
         static readonly OracleConnectionHelper OracleConnectionHelper = new OracleConnectionHelper(ConnectionString);
 
         public static string DatabaseName => $"rebus2_test_{TestConfig.Suffix}".TrimEnd('_');
@@ -45,6 +46,24 @@ namespace Rebus.Oracle.Tests
 
         public static void DropTable(string tableName) => DropTable(tableName, dropSequence: false);
         public static void DropTableAndSequence(string tableName) => DropTable(tableName, dropSequence: true);
+
+        public static void DropProcedure(string procedureName)
+        {
+            using (var connection = OracleConnectionHelper.GetConnection())
+            using (var command = connection.CreateCommand())
+            {
+                try
+                {
+                    command.CommandText = "drop procedure " + procedureName;
+                    command.ExecuteNonQuery();
+                    Console.WriteLine($"Dropped oracle procedure '{procedureName}'");                    
+                }
+                catch (OracleException exception) when (exception.Number == ProcedureDoesNotExist)
+                { }
+
+                connection.Complete();
+            }
+        }
 
         static string GetConnectionStringForDatabase(string databaseName)
         {

--- a/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
+++ b/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.14.0" />
     <PackageReference Include="rebus" Version="6.0.0-b11" />
-    <PackageReference Include="rebus.tests.contracts" Version="6.0.0-b06" />
+    <PackageReference Include="rebus.tests.contracts" Version="6.0.0-b11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
   </ItemGroup>
 </Project>

--- a/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
+++ b/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
@@ -28,10 +28,10 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rebus.Oracle\Rebus.Oracle.csproj" />
-    <PackageReference Include="nunit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="rebus" Version="4.2.1" />
-    <PackageReference Include="rebus.tests.contracts" Version="4.0.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.14.0" />
+    <PackageReference Include="rebus" Version="6.0.0-b11" />
+    <PackageReference Include="rebus.tests.contracts" Version="6.0.0-b06" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
   </ItemGroup>
 </Project>

--- a/Rebus.Oracle.Tests/Sagas/OracleSagaSnapshotTest.cs
+++ b/Rebus.Oracle.Tests/Sagas/OracleSagaSnapshotTest.cs
@@ -4,5 +4,12 @@ using Rebus.Tests.Contracts.Sagas;
 namespace Rebus.Oracle.Tests.Sagas
 {
     [TestFixture, Category(TestCategory.Oracle)]
-    public class OracleSagaSnapshotTest : SagaSnapshotStorageTest<OracleSnapshotStorageFactory> { }
+    public class OracleSagaSnapshotTest : SagaSnapshotStorageTest<OracleSnapshotStorageFactory> 
+    { 
+        protected override void TearDown()
+        {
+            base.TearDown();
+            OracleTestHelper.DropTable(OracleSnapshotStorageFactory.TableName);
+        }
+    }
 }

--- a/Rebus.Oracle.Tests/Sagas/OracleSagaStorageFactory.cs
+++ b/Rebus.Oracle.Tests/Sagas/OracleSagaStorageFactory.cs
@@ -7,12 +7,6 @@ namespace Rebus.Oracle.Tests.Sagas
 {
     public class OracleSagaStorageFactory : ISagaStorageFactory
     {
-        public OracleSagaStorageFactory()
-        {
-            OracleTestHelper.DropTableAndSequence("saga_index");
-            OracleTestHelper.DropTableAndSequence("saga_data");
-        }
-
         public ISagaStorage GetSagaStorage()
         {
             var OracleSagaStorage = new OracleSqlSagaStorage(OracleTestHelper.ConnectionHelper, "saga_data", "saga_index", new ConsoleLoggerFactory(false));
@@ -22,8 +16,8 @@ namespace Rebus.Oracle.Tests.Sagas
 
         public void CleanUp()
         {
-            //OracleTestHelper.DropTable("saga_index");
-            //OracleTestHelper.DropTable("saga_data");
+            OracleTestHelper.DropTable("saga_index");
+            OracleTestHelper.DropTable("saga_data");
         }
     }
 }

--- a/Rebus.Oracle.Tests/Sagas/OracleSnapshotStorageFactory.cs
+++ b/Rebus.Oracle.Tests/Sagas/OracleSnapshotStorageFactory.cs
@@ -9,12 +9,7 @@ namespace Rebus.Oracle.Tests.Sagas
 {
     public class OracleSnapshotStorageFactory : ISagaSnapshotStorageFactory
     {
-        const string TableName = "SagaSnaps";
-
-        public OracleSnapshotStorageFactory()
-        {
-            OracleTestHelper.DropTableAndSequence(TableName);
-        }
+        internal const string TableName = "SagaSnaps";
 
         public ISagaSnapshotStorage Create()
         {

--- a/Rebus.Oracle.Tests/Timeouts/TestOracleTimeoutManager.cs
+++ b/Rebus.Oracle.Tests/Timeouts/TestOracleTimeoutManager.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using Rebus.Logging;
 using Rebus.Oracle.Timeouts;
 using Rebus.Tests.Contracts.Timeouts;
@@ -13,16 +14,13 @@ namespace Rebus.Oracle.Tests.Timeouts
 
     public class OracleTimeoutManagerFactory : ITimeoutManagerFactory
     {
-        public OracleTimeoutManagerFactory()
-        {
-            OracleTestHelper.DropTableAndSequence("timeouts");
-        }
+        readonly FakeRebusTime _fakeRebusTime = new FakeRebusTime();
 
         public ITimeoutManager Create()
         {
-            var OracleTimeoutManager = new OracleTimeoutManager(OracleTestHelper.ConnectionHelper, "timeouts", new ConsoleLoggerFactory(false));
-            OracleTimeoutManager.EnsureTableIsCreated();
-            return OracleTimeoutManager;
+            var oracleTimeoutManager = new OracleTimeoutManager(OracleTestHelper.ConnectionHelper, "timeouts", new ConsoleLoggerFactory(false), _fakeRebusTime);
+            oracleTimeoutManager.EnsureTableIsCreated();
+            return oracleTimeoutManager;
         }
 
         public void Cleanup()
@@ -30,10 +28,11 @@ namespace Rebus.Oracle.Tests.Timeouts
             OracleTestHelper.DropTableAndSequence("timeouts");
         }
 
+        public void FakeIt(DateTimeOffset fakeTime) => _fakeRebusTime.SetNow(fakeTime);
+
         public string GetDebugInfo()
         {
             return "could not provide debug info for this particular timeout manager.... implement if needed :)";
         }
     }
-
 }

--- a/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
+++ b/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
@@ -14,22 +14,23 @@ namespace Rebus.Oracle.Tests.Transport
     public class OracleTransportFactory : ITransportFactory
     {
         readonly string _tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-        readonly HashSet<string> _tablesToDrop = new HashSet<string>();
         readonly List<IDisposable> _disposables = new List<IDisposable>();
+        readonly FakeRebusTime _fakeRebusTime = new FakeRebusTime();
 
         [TestFixture, Category(Categories.Oracle)]
         public class OracleTransportBasicSendReceive : BasicSendReceive<OracleTransportFactory> 
         { }
 
         [TestFixture, Category(Categories.Oracle)]
-        public class OracleTransportMessageExpiration : MessageExpiration<OracleTransportFactory> { }
+        public class OracleTransportMessageExpiration : MessageExpiration<OracleTransportFactory> 
+        { }
 
         public ITransport CreateOneWayClient()
         {
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new OracleTransport(connectionHelper, _tableName, null, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new OracleTransport(connectionHelper, _tableName, null, consoleLoggerFactory, asyncTaskFactory, _fakeRebusTime);
 
             _disposables.Add(transport);
 
@@ -44,7 +45,7 @@ namespace Rebus.Oracle.Tests.Transport
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new OracleTransport(connectionHelper, _tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new OracleTransport(connectionHelper, _tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory, _fakeRebusTime);
 
             _disposables.Add(transport);
 
@@ -62,5 +63,7 @@ namespace Rebus.Oracle.Tests.Transport
             OracleTestHelper.DropTableAndSequence(_tableName);
             OracleTestHelper.DropProcedure("rebus_dequeue_" + _tableName);
         }
+
+        public void FakeIt(DateTimeOffset fakeTime) => _fakeRebusTime.SetNow(fakeTime);
     }
 }

--- a/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
+++ b/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
@@ -28,7 +28,7 @@ namespace Rebus.Oracle.Tests.Transport
         public ITransport CreateOneWayClient()
         {
             var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-             _tablesToDrop.Add(tableName);
+            _tablesToDrop.Add(tableName);
 
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);

--- a/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
+++ b/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
@@ -13,27 +13,23 @@ namespace Rebus.Oracle.Tests.Transport
 {
     public class OracleTransportFactory : ITransportFactory
     {
-
-         readonly HashSet<string> _tablesToDrop = new HashSet<string>();
+        readonly string _tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
+        readonly HashSet<string> _tablesToDrop = new HashSet<string>();
         readonly List<IDisposable> _disposables = new List<IDisposable>();
 
-
         [TestFixture, Category(Categories.Oracle)]
-        public class OracleTransportBasicSendReceive : BasicSendReceive<OracleTransportFactory> { }
+        public class OracleTransportBasicSendReceive : BasicSendReceive<OracleTransportFactory> 
+        { }
 
         [TestFixture, Category(Categories.Oracle)]
         public class OracleTransportMessageExpiration : MessageExpiration<OracleTransportFactory> { }
 
-
         public ITransport CreateOneWayClient()
         {
-            var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-            _tablesToDrop.Add(tableName);
-
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new OracleTransport(connectionHelper, tableName, null, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new OracleTransport(connectionHelper, _tableName, null, consoleLoggerFactory, asyncTaskFactory);
 
             _disposables.Add(transport);
 
@@ -45,14 +41,10 @@ namespace Rebus.Oracle.Tests.Transport
 
         public ITransport Create(string inputQueueAddress)
         {
-            var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-
-            _tablesToDrop.Add(tableName);
-
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new OracleTransport(connectionHelper, tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new OracleTransport(connectionHelper, _tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
 
             _disposables.Add(transport);
 
@@ -67,8 +59,8 @@ namespace Rebus.Oracle.Tests.Transport
             _disposables.ForEach(d => d.Dispose());
             _disposables.Clear();
 
-            _tablesToDrop.ForEach(OracleTestHelper.DropTableAndSequence);
-            _tablesToDrop.Clear();
+            OracleTestHelper.DropTableAndSequence(_tableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + _tableName);
         }
     }
 }

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransport.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransport.cs
@@ -25,7 +25,6 @@ namespace Rebus.Oracle.Tests.Transport
 
         protected override void SetUp()
         {
-            OracleTestHelper.DropTableAndSequence(_tableName);
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
@@ -37,6 +36,12 @@ namespace Rebus.Oracle.Tests.Transport
             _transport.Initialize();
             _cancellationToken = new CancellationTokenSource().Token;
 
+        }
+
+        protected override void TearDown()
+        {
+            OracleTestHelper.DropTableAndSequence(_tableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + _tableName);
         }
 
         [Test]

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransport.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransport.cs
@@ -18,17 +18,17 @@ namespace Rebus.Oracle.Tests.Transport
     [TestFixture, Category(Categories.Oracle)]
     public class TestOracleTransport : FixtureBase
     {
+        const string QueueName = "input";
         readonly string _tableName = "messages" + TestConfig.Suffix;
         OracleTransport _transport;
-        CancellationToken _cancellationToken;
-        const string QueueName = "input";
+        CancellationToken _cancellationToken;        
 
         protected override void SetUp()
         {
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
-            _transport = new OracleTransport(connectionHelper, _tableName, QueueName, consoleLoggerFactory, asyncTaskFactory);
+            _transport = new OracleTransport(connectionHelper, _tableName, QueueName, consoleLoggerFactory, asyncTaskFactory, new FakeRebusTime());
             _transport.EnsureTableIsCreated();
 
             Using(_transport);
@@ -146,9 +146,8 @@ namespace Rebus.Oracle.Tests.Transport
 
             if (kvpsDifferentThanOne.Any())
             {
-                Assert.Fail(@"Oh no! the following IDs were not received exactly once:
-{0}",
-    string.Join(Environment.NewLine, kvpsDifferentThanOne.Select(kvp => $"   {kvp.Key}: {kvp.Value}")));
+                Assert.Fail("Oh no! the following IDs were not received exactly once:\n{0}",
+                            string.Join(Environment.NewLine, kvpsDifferentThanOne.Select(kvp => $"   {kvp.Key}: {kvp.Value}")));
             }
         }
 

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
@@ -18,7 +18,11 @@ namespace Rebus.Oracle.Tests.Transport
     {
         const string QueueName = "test-ordering";
         const string TableName = "Messages";
-        protected override void SetUp() => OracleTestHelper.DropTableAndSequence(TableName);
+        protected override void TearDown()
+        {
+            OracleTestHelper.DropTableAndSequence(TableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + TableName);
+        } 
 
         [Test]
         public async Task DeliversMessagesByVisibleTimeAndNotBeInsertionTime()

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
@@ -14,7 +14,6 @@ using Rebus.Transport;
 namespace Rebus.Oracle.Tests.Transport
 {
     [TestFixture]
-    [Ignore("This one should probably be enabled some time later")]
     public class TestOracleTransportMessageOrdering : FixtureBase
     {
         const string QueueName = "test-ordering";

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
@@ -18,6 +18,7 @@ namespace Rebus.Oracle.Tests.Transport
     {
         const string QueueName = "test-ordering";
         const string TableName = "Messages";
+
         protected override void TearDown()
         {
             OracleTestHelper.DropTableAndSequence(TableName);
@@ -97,7 +98,8 @@ namespace Rebus.Oracle.Tests.Transport
                 TableName,
                 QueueName,
                 loggerFactory,
-                asyncTaskFactory
+                asyncTaskFactory,
+                new FakeRebusTime()
             );
 
             transport.EnsureTableIsCreated();

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportReceivePerformance.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportReceivePerformance.cs
@@ -25,8 +25,6 @@ namespace Rebus.Oracle.Tests.Transport
 
         protected override void SetUp()
         {
-            OracleTestHelper.DropTableAndSequence(TableName);
-
             _adapter = Using(new BuiltinHandlerActivator());
 
             Configure.With(_adapter)
@@ -38,6 +36,12 @@ namespace Rebus.Oracle.Tests.Transport
                     o.SetMaxParallelism(20);
                 })
                 .Start();
+        }
+
+        protected override void TearDown()
+        {
+            OracleTestHelper.DropTableAndSequence(TableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + TableName);
         }
 
         [TestCase(1000)]

--- a/Rebus.Oracle/Config/OracleConfigurationExtensions.cs
+++ b/Rebus.Oracle/Config/OracleConfigurationExtensions.cs
@@ -8,6 +8,7 @@ using Rebus.Oracle.Subscriptions;
 using Rebus.Oracle.Timeouts;
 using Rebus.Sagas;
 using Rebus.Subscriptions;
+using Rebus.Time;
 using Rebus.Timeouts;
 
 namespace Rebus.Config
@@ -68,7 +69,8 @@ namespace Rebus.Config
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var subscriptionStorage = new OracleTimeoutManager(new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction), tableName, rebusLoggerFactory);
+                var rebusTime = c.Get<IRebusTime>();
+                var subscriptionStorage = new OracleTimeoutManager(new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction), tableName, rebusLoggerFactory, rebusTime);
 
                 if (automaticallyCreateTables)
                 {

--- a/Rebus.Oracle/Config/OracleDataBusConfigurationExtensions.cs
+++ b/Rebus.Oracle/Config/OracleDataBusConfigurationExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using Oracle.ManagedDataAccess.Client;
+using Rebus.DataBus;
+using Rebus.Logging;
+using Rebus.Oracle;
+using Rebus.Oracle.DataBus;
+using Rebus.Time;
+
+namespace Rebus.Config
+{
+    /// <summary>
+    /// Configuration extensions for Oracle data bus
+    /// </summary>
+    public static class OracleDataBusConfigurationExtensions
+    {
+        /// <summary>
+        /// Configures the data bus to store data in a central Oracle table
+        /// </summary>
+        public static void StoreInOracle(this StandardConfigurer<IDataBusStorage> configurer, string connectionString, string tableName, Action<OracleConnection> additionalConnectionSetup = null, bool automaticallyCreateTables = true, bool enlistInAmbientTransaction = false)
+        {
+            if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+            if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
+            if (tableName == null) throw new ArgumentNullException(nameof(tableName));
+
+            configurer.Register(c =>
+            {
+                var loggerFactory = c.Get<IRebusLoggerFactory>();
+                var rebusTime = c.Get<IRebusTime>();
+                var connectionHelper = new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction);
+                return new OracleDataBusStorage(connectionHelper, tableName, automaticallyCreateTables, loggerFactory, rebusTime);
+            });
+        }
+    }
+}

--- a/Rebus.Oracle/Config/OracleTransportConfigurationExtensions.cs
+++ b/Rebus.Oracle/Config/OracleTransportConfigurationExtensions.cs
@@ -5,6 +5,7 @@ using Rebus.Oracle.Transport;
 using Rebus.Pipeline;
 using Rebus.Pipeline.Receive;
 using Rebus.Threading;
+using Rebus.Time;
 using Rebus.Timeouts;
 using Rebus.Transport;
 
@@ -43,8 +44,9 @@ namespace Rebus.Config
             {
                 var rebusLoggerFactory = context.Get<IRebusLoggerFactory>();
                 var asyncTaskFactory = context.Get<IAsyncTaskFactory>();
+                var rebusTime = context.Get<IRebusTime>();
                 var connectionProvider = connectionProviderFactory(rebusLoggerFactory);
-                var transport = new OracleTransport(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory);
+                var transport = new OracleTransport(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory, rebusTime);
                 transport.EnsureTableIsCreated();
                 return transport;
             });

--- a/Rebus.Oracle/Oracle/DataBus/OracleDataBusStorage.cs
+++ b/Rebus.Oracle/Oracle/DataBus/OracleDataBusStorage.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Oracle.ManagedDataAccess.Client;
+using Rebus.Bus;
+using Rebus.DataBus;
+using Rebus.Exceptions;
+using Rebus.Logging;
+using Rebus.Serialization;
+using Rebus.Time;
+// ReSharper disable SimplifyLinqExpression
+
+namespace Rebus.Oracle.DataBus
+{
+    /// <summary>
+    /// Implementation of <see cref="IDataBusStorage"/> that uses Oracle to store data
+    /// </summary>
+    public class OracleDataBusStorage : IDataBusStorage, IInitializable
+    {
+        static readonly Encoding TextEncoding = Encoding.UTF8;
+        readonly DictionarySerializer _dictionarySerializer = new DictionarySerializer();
+        readonly OracleConnectionHelper _connectionHelper;
+        readonly string _tableName;
+        readonly bool _ensureTableIsCreated;
+        readonly ILog _log;
+        readonly IRebusTime _rebusTime;
+
+        /// <summary>
+        /// Creates the data storage
+        /// </summary>
+        public OracleDataBusStorage(OracleConnectionHelper connectionHelper, string tableName, bool ensureTableIsCreated, IRebusLoggerFactory rebusLoggerFactory, IRebusTime rebusTime)
+        {
+            if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
+            _connectionHelper = connectionHelper ?? throw new ArgumentNullException(nameof(connectionHelper));
+            _tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
+            _ensureTableIsCreated = ensureTableIsCreated;
+            _log = rebusLoggerFactory.GetLogger<OracleDataBusStorage>();
+            _rebusTime = rebusTime ?? throw new ArgumentNullException(nameof(rebusTime));
+        }
+
+        /// <summary>
+        /// Initializes the SQL Server data storage.
+        /// Will create the data table, unless this has been explicitly turned off when configuring the data storage
+        /// </summary>
+        public void Initialize()
+        {
+            if (!_ensureTableIsCreated) return;
+
+            try
+            {
+                EnsureTableIsCreated();
+            }
+            catch
+            {
+                // if it failed because of a collision between another thread doing the same thing, just try again once:
+                EnsureTableIsCreated();
+            }
+        }
+
+        void EnsureTableIsCreated()
+        {
+            using (var connection = _connectionHelper.GetConnection())
+            {
+                if (connection.GetTableNames().Contains(_tableName, StringComparer.OrdinalIgnoreCase))
+                {
+                    _log.Info("Database already contains a table named {tableName} - will not create anything", _tableName);
+                    return;
+                }
+
+                _log.Info("Creating data bus table {tableName}", _tableName);
+
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = $@"
+CREATE TABLE {_tableName} (
+    id VARCHAR2(200) PRIMARY KEY,
+    meta BLOB,
+    data BLOB NOT NULL,
+    creationTime TIMESTAMP WITH TIME ZONE NOT NULL,
+    lastReadTime TIMESTAMP WITH TIME ZONE
+)";
+                    try
+                    {
+                        command.ExecuteNonQuery();
+                    }
+                    catch (OracleException exception)
+                    {
+                        throw new RebusApplicationException(exception, "Error executing SQL command\n" + command.CommandText);
+                    }
+                }
+
+                // Note: calling connection.Complete() is not required as Oracle DDL is not transactional
+            }
+        }
+
+        /// <summary>
+        /// Saves the data from the given source stream under the given ID
+        /// </summary>
+        public Task Save(string id, Stream source, Dictionary<string, string> metadata = null)
+        {
+            try
+            {
+                using (var connection = _connectionHelper.GetConnection())
+                {
+                    using (var blob = connection.CreateBlob())
+                    {
+                        source.CopyTo(blob);
+
+                        using (var command = connection.CreateCommand())
+                        {
+                            var metadataBytes = metadata == null ? 
+                                null : 
+                                TextEncoding.GetBytes(_dictionarySerializer.SerializeToString(metadata));
+
+                            command.CommandText = $"INSERT INTO {_tableName} (id, meta, data, creationTime) VALUES (:id, :meta, :data, :now)";
+                            command.BindByName = true;
+                            command.Parameters.Add("id", id);
+                            command.Parameters.Add("meta", (object)metadataBytes ?? DBNull.Value);
+                            command.Parameters.Add("data", blob);
+                            command.Parameters.Add("now", _rebusTime.Now.ToOracleTimeStamp());
+
+                            command.ExecuteNonQuery();
+                        }
+                    }
+                    
+                    connection.Complete();
+                    return Task.CompletedTask;
+                }
+            }
+            catch (Exception exception)
+            {
+                throw new RebusApplicationException(exception, $"Could not save data with ID {id}");
+            }
+        }
+
+        /// <summary>
+        /// Opens the data stored under the given ID for reading
+        /// </summary>
+        public Task<Stream> Read(string id)
+        {
+            try
+            {
+                // update last read time quickly
+                UpdateLastReadTime(id);
+
+                OracleDbConnection connection = null;
+                OracleCommand command = null;
+                OracleDataReader reader = null;
+
+                try
+                {
+                    connection = _connectionHelper.GetConnection();
+
+                    command = connection.CreateCommand();
+                    command.CommandText = $"SELECT data FROM {_tableName} WHERE id = :id";
+                    command.Parameters.Add("id", id);
+                    command.InitialLOBFetchSize = 4000;
+
+                    reader = command.ExecuteReader(CommandBehavior.SingleRow);
+
+                    if (!reader.Read())
+                        throw new ArgumentException($"DataBus row with ID {id} not found");
+
+                    var blob = reader.GetOracleBlob(0);
+
+                    return Task.FromResult<Stream>(new StreamWrapper(blob, /* dispose with stream: */ reader, command, connection));
+                }
+                catch
+                {
+                    // if something of the above fails, we did not pass ownership to someone who can dispose it... therefore:
+                    reader?.Dispose();
+                    command?.Dispose();
+                    connection?.Dispose();
+                    throw;
+                }
+            }
+            catch (Exception exception)
+            {
+                // Wrap in AggregateException to comply with Rebus contract. Tests do look for this specific exception type.
+                throw new AggregateException(exception);
+            }
+        }
+
+        void UpdateLastReadTime(string id)
+        {
+            using (var connection = _connectionHelper.GetConnection())
+            {
+                UpdateLastReadTime(id, connection);
+                connection.Complete();
+            }
+        }
+
+        void UpdateLastReadTime(string id, OracleDbConnection connection)
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = $"UPDATE {_tableName} SET lastReadTime = :now WHERE id = :id";
+                command.BindByName = true;
+                command.Parameters.Add("now", _rebusTime.Now.ToOracleTimeStamp());
+                command.Parameters.Add("id", id);
+                command.ExecuteNonQuery();
+            }
+        }
+
+        /// <summary>
+        /// Loads the metadata stored with the given ID
+        /// </summary>
+        public Task<Dictionary<string, string>> ReadMetadata(string id)
+        {
+            try
+            {
+                using (var connection =  _connectionHelper.GetConnection())
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = $"SELECT meta, creationTime, lastReadTime, LENGTHB(data) AS dataLength FROM {_tableName} WHERE id = :id";
+                    command.Parameters.Add("id", id);
+
+                    using (var reader = command.ExecuteReader(CommandBehavior.SingleRow))
+                    {
+                        if (!reader.Read())
+                            throw new ArgumentException($"DataBus row with ID {id} not found");
+
+                        var metaDbValue = reader["meta"];
+                        var dataLength = reader.GetInt64(reader.GetOrdinal("dataLength"));
+                        var creationTime = reader.GetOracleTimeStampTZ(reader.GetOrdinal("creationTime")).ToDateTimeOffset();
+                        var lastReadTimeIndex = reader.GetOrdinal("lastReadTime");
+                        var lastReadTime = reader.IsDBNull(lastReadTimeIndex) ?
+                            (DateTimeOffset?)null :
+                            reader.GetOracleTimeStampTZ(lastReadTimeIndex).ToDateTimeOffset();
+
+                        var metadata = metaDbValue is DBNull ?
+                            new Dictionary<string, string>() :
+                            _dictionarySerializer.DeserializeFromString(TextEncoding.GetString((byte[])metaDbValue));
+
+                        metadata[MetadataKeys.Length] = dataLength.ToString();
+                        metadata[MetadataKeys.SaveTime] = creationTime.ToString("O");
+
+                        if (lastReadTime != null)
+                        {
+                            metadata[MetadataKeys.ReadTime] = lastReadTime.Value.ToString("O");
+                        }
+
+                        return Task.FromResult(metadata);
+                    }
+                }
+            }
+            catch (Exception exception) when (!(exception is ArgumentException))
+            {
+                throw new RebusApplicationException(exception, $"Could not load metadata for data with ID {id}");
+            }
+        }
+    }
+}

--- a/Rebus.Oracle/Oracle/DataBus/StreamWrapper.cs
+++ b/Rebus.Oracle/Oracle/DataBus/StreamWrapper.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+
+namespace Rebus.Oracle.DataBus
+{
+    /// <summary>Wraps a stream and additional resources, disposing them when the stream is disposed</summary>
+    class StreamWrapper : Stream
+    {
+        readonly Stream _innerStream;
+        readonly IDisposable[] _disposables;
+
+        public StreamWrapper(Stream innerStream, params IDisposable[] disposables)
+        {
+            if (innerStream == null) throw new ArgumentNullException(nameof(innerStream));
+            _innerStream = innerStream;
+            _disposables = disposables;
+        }
+
+        public override void Flush() => _innerStream.Flush();
+
+        public override long Seek(long offset, SeekOrigin origin) => _innerStream.Seek(offset, origin);
+
+        public override void SetLength(long value) => _innerStream.SetLength(value);
+
+        public override int Read(byte[] buffer, int offset, int count) => _innerStream.Read(buffer, offset, count);
+
+        public override void Write(byte[] buffer, int offset, int count) => _innerStream.Write(buffer, offset, count);
+
+        public override bool CanRead => _innerStream.CanRead;
+        public override bool CanSeek => _innerStream.CanSeek;
+        public override bool CanWrite => _innerStream.CanWrite;
+        public override long Length => _innerStream.Length;
+
+        public override long Position
+        {
+            get => _innerStream.Position;
+            set => _innerStream.Position = value;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _innerStream.Dispose();
+
+            foreach (var disposable in _disposables)
+            {
+                disposable.Dispose();
+            }            
+        }
+    }
+}

--- a/Rebus.Oracle/Oracle/Magic.cs
+++ b/Rebus.Oracle/Oracle/Magic.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Oracle.ManagedDataAccess.Types;
 
 namespace Rebus.Oracle
 {
@@ -22,6 +25,16 @@ namespace Rebus.Oracle
             }
 
             return tableNames;
+        }
+
+        public static DateTimeOffset ToDateTimeOffset(this OracleTimeStampTZ value)
+        {
+            return new DateTimeOffset(value.Value, value.GetTimeZoneOffset());
+        }
+
+        public static OracleTimeStampTZ ToOracleTimeStamp(this DateTimeOffset value)
+        {
+            return new OracleTimeStampTZ(value.DateTime, value.Offset.ToString("c", CultureInfo.InvariantCulture));
         }
     }
 }

--- a/Rebus.Oracle/Oracle/OracleDbConnection.cs
+++ b/Rebus.Oracle/Oracle/OracleDbConnection.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Threading.Tasks;
 using Oracle.ManagedDataAccess.Client;
+using Oracle.ManagedDataAccess.Types;
 
 // ReSharper disable EmptyGeneralCatchClause
 #pragma warning disable 1998
@@ -13,6 +13,7 @@ namespace Rebus.Oracle
     public class OracleDbConnection : IDisposable
     {
         readonly OracleConnection _currentConnection;
+        
         OracleTransaction _currentTransaction;
 
         bool _disposed;
@@ -35,6 +36,11 @@ namespace Rebus.Oracle
             command.Transaction = _currentTransaction;
             return command;
         }
+
+        /// <summary>
+        /// Creates a new blob, associated with the current connection
+        /// </summary>
+        public OracleBlob CreateBlob() => new OracleBlob(_currentConnection);
 
         /// <summary>
         /// Completes the transaction

--- a/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
+++ b/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
@@ -307,13 +307,15 @@ begin
     WHERE recipient = recipientQueue
             and visible < current_timestamp(6)
             and expiration > current_timestamp(6)          
-    ORDER BY priority ASC, id ASC
+    ORDER BY priority ASC, visible ASC, id ASC
     for update skip locked;
     
     fetch readCursor into messageId;
-    close readCursor;      
-  open output for select * from {_tableName} where id = messageId;
-  delete from {_tableName} where id = messageId;
+    close readCursor;
+
+    open output for select * from {_tableName} where id = messageId;
+
+    delete from {_tableName} where id = messageId;
 END;
 ");
 

--- a/Rebus.Oracle/Rebus.Oracle.csproj
+++ b/Rebus.Oracle/Rebus.Oracle.csproj
@@ -41,8 +41,8 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.12.0-beta3" />
-    <PackageReference Include="Rebus" Version="4.2.1" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.18.3" />
+    <PackageReference Include="Rebus" Version="6.0.0-b11" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />


### PR DESCRIPTION
This is done on top of #20.

Mostly copied from SQL Server implementation, including tests.

Design is the same as other databus: 
- No shared transaction with transport;
- No garbage collection -> user is responsible to decide if he wants to delete attachements based on creationDate, lastReadDate or detect if they are referenced by a message. I did not create indexes, favouring insertion performance; users can add extra indexes based on how they want to clean up this table.

All 79 tests green on Oracle 11.

Fixes #11