### PR TITLE
Fix tests

### DIFF
--- a/Rebus.Oracle.Tests/Integration/TestOracleAllTheWay.cs
+++ b/Rebus.Oracle.Tests/Integration/TestOracleAllTheWay.cs
@@ -22,8 +22,6 @@ namespace Rebus.Oracle.Tests.Integration
 
         protected override void SetUp()
         {
-            DropTables();
-
             _activator = new BuiltinHandlerActivator();
 
             Using(_activator);
@@ -40,12 +38,8 @@ namespace Rebus.Oracle.Tests.Integration
 
         protected override void TearDown()
         {
-            DropTables();
-        }
-
-        static void DropTables()
-        {
             OracleTestHelper.DropTableAndSequence("transports");
+            OracleTestHelper.DropProcedure("rebus_dequeue_transports");
         }
 
         [Test]

--- a/Rebus.Oracle.Tests/OracleTestHelper.cs
+++ b/Rebus.Oracle.Tests/OracleTestHelper.cs
@@ -16,44 +16,35 @@ namespace Rebus.Oracle.Tests
 
         public static OracleConnectionHelper ConnectionHelper => OracleConnectionHelper;
 
-        public static void DropTableAndSequence(string tableName)
+        static void DropTable(string tableName, bool dropSequence)
         {
             using (var connection = OracleConnectionHelper.GetConnection())
+            using (var command = connection.CreateCommand())
             {
-                using (var comand = connection.CreateCommand())
+                try
                 {
-                    comand.CommandText = $@"drop table {tableName}";
-
-                    try
-                    {
-                        comand.ExecuteNonQuery();
-
-                        Console.WriteLine("Dropped oracle table '{0}'", tableName);
-                    }
-                    catch (OracleException exception) when (exception.Number == TableDoesNotExist)
-                    {
-                    }
+                    command.CommandText = "drop table " + tableName;
+                    command.ExecuteNonQuery();
+                    Console.WriteLine($"Dropped oracle table '{tableName}'");                    
                 }
-
-                using (var comand = connection.CreateCommand())
+                catch (OracleException exception) when (exception.Number == TableDoesNotExist)
+                { }
+                
+                try
                 {
-                    comand.CommandText = $@"drop sequence {tableName}_SEQ";
-
-                    try
-                    {
-                        comand.ExecuteNonQuery();
-
-                        Console.WriteLine("Dropped oracle sequence '{0}_SEQ'", tableName);
-                    }
-                    catch (OracleException exception) when (exception.Number ==SequenceDoesNotExist)
-                    {
-                    }
+                    command.CommandText = $"drop sequence {tableName}_SEQ";
+                    command.ExecuteNonQuery();
+                    Console.WriteLine("Dropped oracle sequence '{0}_SEQ'", tableName);
                 }
-
+                catch (OracleException exception) when (exception.Number == SequenceDoesNotExist)
+                { }
 
                 connection.Complete();
             }
         }
+
+        public static void DropTable(string tableName) => DropTable(tableName, dropSequence: false);
+        public static void DropTableAndSequence(string tableName) => DropTable(tableName, dropSequence: true);
 
         static string GetConnectionStringForDatabase(string databaseName)
         {

--- a/Rebus.Oracle.Tests/OracleTestHelper.cs
+++ b/Rebus.Oracle.Tests/OracleTestHelper.cs
@@ -8,6 +8,7 @@ namespace Rebus.Oracle.Tests
     {
         const int TableDoesNotExist = 942;
         const int SequenceDoesNotExist = 2289;
+        const int ProcedureDoesNotExist = 4043;
         static readonly OracleConnectionHelper OracleConnectionHelper = new OracleConnectionHelper(ConnectionString);
 
         public static string DatabaseName => $"rebus2_test_{TestConfig.Suffix}".TrimEnd('_');
@@ -45,6 +46,24 @@ namespace Rebus.Oracle.Tests
 
         public static void DropTable(string tableName) => DropTable(tableName, dropSequence: false);
         public static void DropTableAndSequence(string tableName) => DropTable(tableName, dropSequence: true);
+
+        public static void DropProcedure(string procedureName)
+        {
+            using (var connection = OracleConnectionHelper.GetConnection())
+            using (var command = connection.CreateCommand())
+            {
+                try
+                {
+                    command.CommandText = "drop procedure " + procedureName;
+                    command.ExecuteNonQuery();
+                    Console.WriteLine($"Dropped oracle procedure '{procedureName}'");                    
+                }
+                catch (OracleException exception) when (exception.Number == ProcedureDoesNotExist)
+                { }
+
+                connection.Complete();
+            }
+        }
 
         static string GetConnectionStringForDatabase(string databaseName)
         {

--- a/Rebus.Oracle.Tests/Sagas/OracleSagaSnapshotTest.cs
+++ b/Rebus.Oracle.Tests/Sagas/OracleSagaSnapshotTest.cs
@@ -4,5 +4,12 @@ using Rebus.Tests.Contracts.Sagas;
 namespace Rebus.Oracle.Tests.Sagas
 {
     [TestFixture, Category(TestCategory.Oracle)]
-    public class OracleSagaSnapshotTest : SagaSnapshotStorageTest<OracleSnapshotStorageFactory> { }
+    public class OracleSagaSnapshotTest : SagaSnapshotStorageTest<OracleSnapshotStorageFactory> 
+    { 
+        protected override void TearDown()
+        {
+            base.TearDown();
+            OracleTestHelper.DropTable(OracleSnapshotStorageFactory.TableName);
+        }
+    }
 }

--- a/Rebus.Oracle.Tests/Sagas/OracleSagaStorageFactory.cs
+++ b/Rebus.Oracle.Tests/Sagas/OracleSagaStorageFactory.cs
@@ -7,12 +7,6 @@ namespace Rebus.Oracle.Tests.Sagas
 {
     public class OracleSagaStorageFactory : ISagaStorageFactory
     {
-        public OracleSagaStorageFactory()
-        {
-            OracleTestHelper.DropTableAndSequence("saga_index");
-            OracleTestHelper.DropTableAndSequence("saga_data");
-        }
-
         public ISagaStorage GetSagaStorage()
         {
             var OracleSagaStorage = new OracleSqlSagaStorage(OracleTestHelper.ConnectionHelper, "saga_data", "saga_index", new ConsoleLoggerFactory(false));
@@ -22,8 +16,8 @@ namespace Rebus.Oracle.Tests.Sagas
 
         public void CleanUp()
         {
-            //OracleTestHelper.DropTable("saga_index");
-            //OracleTestHelper.DropTable("saga_data");
+            OracleTestHelper.DropTable("saga_index");
+            OracleTestHelper.DropTable("saga_data");
         }
     }
 }

--- a/Rebus.Oracle.Tests/Sagas/OracleSnapshotStorageFactory.cs
+++ b/Rebus.Oracle.Tests/Sagas/OracleSnapshotStorageFactory.cs
@@ -9,12 +9,7 @@ namespace Rebus.Oracle.Tests.Sagas
 {
     public class OracleSnapshotStorageFactory : ISagaSnapshotStorageFactory
     {
-        const string TableName = "SagaSnaps";
-
-        public OracleSnapshotStorageFactory()
-        {
-            OracleTestHelper.DropTableAndSequence(TableName);
-        }
+        internal const string TableName = "SagaSnaps";
 
         public ISagaSnapshotStorage Create()
         {

--- a/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
+++ b/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
@@ -28,7 +28,7 @@ namespace Rebus.Oracle.Tests.Transport
         public ITransport CreateOneWayClient()
         {
             var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-             _tablesToDrop.Add(tableName);
+            _tablesToDrop.Add(tableName);
 
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);

--- a/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
+++ b/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
@@ -13,27 +13,23 @@ namespace Rebus.Oracle.Tests.Transport
 {
     public class OracleTransportFactory : ITransportFactory
     {
-
-         readonly HashSet<string> _tablesToDrop = new HashSet<string>();
+        readonly string _tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
+        readonly HashSet<string> _tablesToDrop = new HashSet<string>();
         readonly List<IDisposable> _disposables = new List<IDisposable>();
 
-
         [TestFixture, Category(Categories.Oracle)]
-        public class OracleTransportBasicSendReceive : BasicSendReceive<OracleTransportFactory> { }
+        public class OracleTransportBasicSendReceive : BasicSendReceive<OracleTransportFactory> 
+        { }
 
         [TestFixture, Category(Categories.Oracle)]
         public class OracleTransportMessageExpiration : MessageExpiration<OracleTransportFactory> { }
 
-
         public ITransport CreateOneWayClient()
         {
-            var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-            _tablesToDrop.Add(tableName);
-
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new OracleTransport(connectionHelper, tableName, null, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new OracleTransport(connectionHelper, _tableName, null, consoleLoggerFactory, asyncTaskFactory);
 
             _disposables.Add(transport);
 
@@ -45,14 +41,10 @@ namespace Rebus.Oracle.Tests.Transport
 
         public ITransport Create(string inputQueueAddress)
         {
-            var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-
-            _tablesToDrop.Add(tableName);
-
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new OracleTransport(connectionHelper, tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new OracleTransport(connectionHelper, _tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
 
             _disposables.Add(transport);
 
@@ -67,8 +59,8 @@ namespace Rebus.Oracle.Tests.Transport
             _disposables.ForEach(d => d.Dispose());
             _disposables.Clear();
 
-            _tablesToDrop.ForEach(OracleTestHelper.DropTableAndSequence);
-            _tablesToDrop.Clear();
+            OracleTestHelper.DropTableAndSequence(_tableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + _tableName);
         }
     }
 }

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransport.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransport.cs
@@ -25,7 +25,6 @@ namespace Rebus.Oracle.Tests.Transport
 
         protected override void SetUp()
         {
-            OracleTestHelper.DropTableAndSequence(_tableName);
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
@@ -37,6 +36,12 @@ namespace Rebus.Oracle.Tests.Transport
             _transport.Initialize();
             _cancellationToken = new CancellationTokenSource().Token;
 
+        }
+
+        protected override void TearDown()
+        {
+            OracleTestHelper.DropTableAndSequence(_tableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + _tableName);
         }
 
         [Test]

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
@@ -18,7 +18,11 @@ namespace Rebus.Oracle.Tests.Transport
     {
         const string QueueName = "test-ordering";
         const string TableName = "Messages";
-        protected override void SetUp() => OracleTestHelper.DropTableAndSequence(TableName);
+        protected override void TearDown()
+        {
+            OracleTestHelper.DropTableAndSequence(TableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + TableName);
+        } 
 
         [Test]
         public async Task DeliversMessagesByVisibleTimeAndNotBeInsertionTime()

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
@@ -14,7 +14,6 @@ using Rebus.Transport;
 namespace Rebus.Oracle.Tests.Transport
 {
     [TestFixture]
-    [Ignore("This one should probably be enabled some time later")]
     public class TestOracleTransportMessageOrdering : FixtureBase
     {
         const string QueueName = "test-ordering";

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportReceivePerformance.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportReceivePerformance.cs
@@ -25,8 +25,6 @@ namespace Rebus.Oracle.Tests.Transport
 
         protected override void SetUp()
         {
-            OracleTestHelper.DropTableAndSequence(TableName);
-
             _adapter = Using(new BuiltinHandlerActivator());
 
             Configure.With(_adapter)
@@ -38,6 +36,12 @@ namespace Rebus.Oracle.Tests.Transport
                     o.SetMaxParallelism(20);
                 })
                 .Start();
+        }
+
+        protected override void TearDown()
+        {
+            OracleTestHelper.DropTableAndSequence(TableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + TableName);
         }
 
         [TestCase(1000)]

--- a/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
+++ b/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
@@ -307,13 +307,15 @@ begin
     WHERE recipient = recipientQueue
             and visible < current_timestamp(6)
             and expiration > current_timestamp(6)          
-    ORDER BY priority ASC, id ASC
+    ORDER BY priority ASC, visible ASC, id ASC
     for update skip locked;
     
     fetch readCursor into messageId;
-    close readCursor;      
-  open output for select * from {_tableName} where id = messageId;
-  delete from {_tableName} where id = messageId;
+    close readCursor;
+
+    open output for select * from {_tableName} where id = messageId;
+
+    delete from {_tableName} where id = messageId;
 END;
 ");
 


### PR DESCRIPTION
1. Fix regressions caused by #17 
It's all because Saga exceptions were not `AggregateException` anymore, so I wrapped them.

2. Enable and fix the skipped test
It failed because of dequeue was not ordered by visible time.

3. Ensure we drop everything after tests, including procedures, etc.
So that your DB stays clean!

**EDIT**: the 4 flaky tests seem to pass consistently on Rebus 6 (see #20)

----
@mookid8000 @thomasdc I need your help with 3 flaky tests.
Namely `CanSendAndReceive`, `MessageIsReturnedToQueueWhenReceivingTransactionIsNotCommitted` and `ReceivesSentMessageWhenTransactionIsCommitted`.
Those are all basic send/receive contract tests from Rebus.

They fail even before #17 so I don't think those changes are to blame.

When I run the full suite they almost always fail.
When I run the fixture often 2 out of 3 fail.
When I run the fixture with `--verbose n` (so more time is spent writing to console), they all pass.
When I run them individually they all pass.
When I run the three of them, usually just 1 fails.

I'm suspecting that there are race conditions somewhere (maybe missing `await` or whatnot).
Considering that (correct me if I'm wrong):
- NUnit doesn't run tests in parallel unless explicitly asked;
- TearDown is run between each test and drops the full table;

I don't see any explanation than race conditions.

**EDIT**: `HasOneWayClient` also fails, sometimes.