### PR TITLE
Rebus 6

### DIFF
--- a/Rebus.Oracle.Tests/FakeRebusTime.cs
+++ b/Rebus.Oracle.Tests/FakeRebusTime.cs
@@ -1,0 +1,14 @@
+using System;
+using Rebus.Time;
+
+namespace Rebus.Oracle.Tests
+{
+    class FakeRebusTime : IRebusTime
+    {
+        Func<DateTimeOffset> _nowFactory = () => DateTimeOffset.Now;
+
+        public DateTimeOffset Now => _nowFactory();
+
+        public void SetNow(DateTimeOffset fakeTime) => _nowFactory = () => fakeTime;
+    }
+}

--- a/Rebus.Oracle.Tests/Integration/TestOracleAllTheWay.cs
+++ b/Rebus.Oracle.Tests/Integration/TestOracleAllTheWay.cs
@@ -22,8 +22,6 @@ namespace Rebus.Oracle.Tests.Integration
 
         protected override void SetUp()
         {
-            DropTables();
-
             _activator = new BuiltinHandlerActivator();
 
             Using(_activator);
@@ -40,12 +38,8 @@ namespace Rebus.Oracle.Tests.Integration
 
         protected override void TearDown()
         {
-            DropTables();
-        }
-
-        static void DropTables()
-        {
             OracleTestHelper.DropTableAndSequence("transports");
+            OracleTestHelper.DropProcedure("rebus_dequeue_transports");
         }
 
         [Test]

--- a/Rebus.Oracle.Tests/OracleTestHelper.cs
+++ b/Rebus.Oracle.Tests/OracleTestHelper.cs
@@ -16,44 +16,35 @@ namespace Rebus.Oracle.Tests
 
         public static OracleConnectionHelper ConnectionHelper => OracleConnectionHelper;
 
-        public static void DropTableAndSequence(string tableName)
+        static void DropTable(string tableName, bool dropSequence)
         {
             using (var connection = OracleConnectionHelper.GetConnection())
+            using (var command = connection.CreateCommand())
             {
-                using (var comand = connection.CreateCommand())
+                try
                 {
-                    comand.CommandText = $@"drop table {tableName}";
-
-                    try
-                    {
-                        comand.ExecuteNonQuery();
-
-                        Console.WriteLine("Dropped oracle table '{0}'", tableName);
-                    }
-                    catch (OracleException exception) when (exception.Number == TableDoesNotExist)
-                    {
-                    }
+                    command.CommandText = "drop table " + tableName;
+                    command.ExecuteNonQuery();
+                    Console.WriteLine($"Dropped oracle table '{tableName}'");                    
                 }
-
-                using (var comand = connection.CreateCommand())
+                catch (OracleException exception) when (exception.Number == TableDoesNotExist)
+                { }
+                
+                try
                 {
-                    comand.CommandText = $@"drop sequence {tableName}_SEQ";
-
-                    try
-                    {
-                        comand.ExecuteNonQuery();
-
-                        Console.WriteLine("Dropped oracle sequence '{0}_SEQ'", tableName);
-                    }
-                    catch (OracleException exception) when (exception.Number ==SequenceDoesNotExist)
-                    {
-                    }
+                    command.CommandText = $"drop sequence {tableName}_SEQ";
+                    command.ExecuteNonQuery();
+                    Console.WriteLine("Dropped oracle sequence '{0}_SEQ'", tableName);
                 }
-
+                catch (OracleException exception) when (exception.Number == SequenceDoesNotExist)
+                { }
 
                 connection.Complete();
             }
         }
+
+        public static void DropTable(string tableName) => DropTable(tableName, dropSequence: false);
+        public static void DropTableAndSequence(string tableName) => DropTable(tableName, dropSequence: true);
 
         static string GetConnectionStringForDatabase(string databaseName)
         {

--- a/Rebus.Oracle.Tests/OracleTestHelper.cs
+++ b/Rebus.Oracle.Tests/OracleTestHelper.cs
@@ -8,6 +8,7 @@ namespace Rebus.Oracle.Tests
     {
         const int TableDoesNotExist = 942;
         const int SequenceDoesNotExist = 2289;
+        const int ProcedureDoesNotExist = 4043;
         static readonly OracleConnectionHelper OracleConnectionHelper = new OracleConnectionHelper(ConnectionString);
 
         public static string DatabaseName => $"rebus2_test_{TestConfig.Suffix}".TrimEnd('_');
@@ -45,6 +46,24 @@ namespace Rebus.Oracle.Tests
 
         public static void DropTable(string tableName) => DropTable(tableName, dropSequence: false);
         public static void DropTableAndSequence(string tableName) => DropTable(tableName, dropSequence: true);
+
+        public static void DropProcedure(string procedureName)
+        {
+            using (var connection = OracleConnectionHelper.GetConnection())
+            using (var command = connection.CreateCommand())
+            {
+                try
+                {
+                    command.CommandText = "drop procedure " + procedureName;
+                    command.ExecuteNonQuery();
+                    Console.WriteLine($"Dropped oracle procedure '{procedureName}'");                    
+                }
+                catch (OracleException exception) when (exception.Number == ProcedureDoesNotExist)
+                { }
+
+                connection.Complete();
+            }
+        }
 
         static string GetConnectionStringForDatabase(string databaseName)
         {

--- a/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
+++ b/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.14.0" />
     <PackageReference Include="rebus" Version="6.0.0-b11" />
-    <PackageReference Include="rebus.tests.contracts" Version="6.0.0-b06" />
+    <PackageReference Include="rebus.tests.contracts" Version="6.0.0-b11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
   </ItemGroup>
 </Project>

--- a/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
+++ b/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
@@ -28,10 +28,10 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rebus.Oracle\Rebus.Oracle.csproj" />
-    <PackageReference Include="nunit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="rebus" Version="4.2.1" />
-    <PackageReference Include="rebus.tests.contracts" Version="4.0.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.14.0" />
+    <PackageReference Include="rebus" Version="6.0.0-b11" />
+    <PackageReference Include="rebus.tests.contracts" Version="6.0.0-b06" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
   </ItemGroup>
 </Project>

--- a/Rebus.Oracle.Tests/Sagas/OracleSagaSnapshotTest.cs
+++ b/Rebus.Oracle.Tests/Sagas/OracleSagaSnapshotTest.cs
@@ -4,5 +4,12 @@ using Rebus.Tests.Contracts.Sagas;
 namespace Rebus.Oracle.Tests.Sagas
 {
     [TestFixture, Category(TestCategory.Oracle)]
-    public class OracleSagaSnapshotTest : SagaSnapshotStorageTest<OracleSnapshotStorageFactory> { }
+    public class OracleSagaSnapshotTest : SagaSnapshotStorageTest<OracleSnapshotStorageFactory> 
+    { 
+        protected override void TearDown()
+        {
+            base.TearDown();
+            OracleTestHelper.DropTable(OracleSnapshotStorageFactory.TableName);
+        }
+    }
 }

--- a/Rebus.Oracle.Tests/Sagas/OracleSagaStorageFactory.cs
+++ b/Rebus.Oracle.Tests/Sagas/OracleSagaStorageFactory.cs
@@ -7,12 +7,6 @@ namespace Rebus.Oracle.Tests.Sagas
 {
     public class OracleSagaStorageFactory : ISagaStorageFactory
     {
-        public OracleSagaStorageFactory()
-        {
-            OracleTestHelper.DropTableAndSequence("saga_index");
-            OracleTestHelper.DropTableAndSequence("saga_data");
-        }
-
         public ISagaStorage GetSagaStorage()
         {
             var OracleSagaStorage = new OracleSqlSagaStorage(OracleTestHelper.ConnectionHelper, "saga_data", "saga_index", new ConsoleLoggerFactory(false));
@@ -22,8 +16,8 @@ namespace Rebus.Oracle.Tests.Sagas
 
         public void CleanUp()
         {
-            //OracleTestHelper.DropTable("saga_index");
-            //OracleTestHelper.DropTable("saga_data");
+            OracleTestHelper.DropTable("saga_index");
+            OracleTestHelper.DropTable("saga_data");
         }
     }
 }

--- a/Rebus.Oracle.Tests/Sagas/OracleSnapshotStorageFactory.cs
+++ b/Rebus.Oracle.Tests/Sagas/OracleSnapshotStorageFactory.cs
@@ -9,12 +9,7 @@ namespace Rebus.Oracle.Tests.Sagas
 {
     public class OracleSnapshotStorageFactory : ISagaSnapshotStorageFactory
     {
-        const string TableName = "SagaSnaps";
-
-        public OracleSnapshotStorageFactory()
-        {
-            OracleTestHelper.DropTableAndSequence(TableName);
-        }
+        internal const string TableName = "SagaSnaps";
 
         public ISagaSnapshotStorage Create()
         {

--- a/Rebus.Oracle.Tests/Timeouts/TestOracleTimeoutManager.cs
+++ b/Rebus.Oracle.Tests/Timeouts/TestOracleTimeoutManager.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using Rebus.Logging;
 using Rebus.Oracle.Timeouts;
 using Rebus.Tests.Contracts.Timeouts;
@@ -13,16 +14,13 @@ namespace Rebus.Oracle.Tests.Timeouts
 
     public class OracleTimeoutManagerFactory : ITimeoutManagerFactory
     {
-        public OracleTimeoutManagerFactory()
-        {
-            OracleTestHelper.DropTableAndSequence("timeouts");
-        }
+        readonly FakeRebusTime _fakeRebusTime = new FakeRebusTime();
 
         public ITimeoutManager Create()
         {
-            var OracleTimeoutManager = new OracleTimeoutManager(OracleTestHelper.ConnectionHelper, "timeouts", new ConsoleLoggerFactory(false));
-            OracleTimeoutManager.EnsureTableIsCreated();
-            return OracleTimeoutManager;
+            var oracleTimeoutManager = new OracleTimeoutManager(OracleTestHelper.ConnectionHelper, "timeouts", new ConsoleLoggerFactory(false), _fakeRebusTime);
+            oracleTimeoutManager.EnsureTableIsCreated();
+            return oracleTimeoutManager;
         }
 
         public void Cleanup()
@@ -30,10 +28,11 @@ namespace Rebus.Oracle.Tests.Timeouts
             OracleTestHelper.DropTableAndSequence("timeouts");
         }
 
+        public void FakeIt(DateTimeOffset fakeTime) => _fakeRebusTime.SetNow(fakeTime);
+
         public string GetDebugInfo()
         {
             return "could not provide debug info for this particular timeout manager.... implement if needed :)";
         }
     }
-
 }

--- a/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
+++ b/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
@@ -14,22 +14,23 @@ namespace Rebus.Oracle.Tests.Transport
     public class OracleTransportFactory : ITransportFactory
     {
         readonly string _tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-        readonly HashSet<string> _tablesToDrop = new HashSet<string>();
         readonly List<IDisposable> _disposables = new List<IDisposable>();
+        readonly FakeRebusTime _fakeRebusTime = new FakeRebusTime();
 
         [TestFixture, Category(Categories.Oracle)]
         public class OracleTransportBasicSendReceive : BasicSendReceive<OracleTransportFactory> 
         { }
 
         [TestFixture, Category(Categories.Oracle)]
-        public class OracleTransportMessageExpiration : MessageExpiration<OracleTransportFactory> { }
+        public class OracleTransportMessageExpiration : MessageExpiration<OracleTransportFactory> 
+        { }
 
         public ITransport CreateOneWayClient()
         {
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new OracleTransport(connectionHelper, _tableName, null, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new OracleTransport(connectionHelper, _tableName, null, consoleLoggerFactory, asyncTaskFactory, _fakeRebusTime);
 
             _disposables.Add(transport);
 
@@ -44,7 +45,7 @@ namespace Rebus.Oracle.Tests.Transport
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new OracleTransport(connectionHelper, _tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new OracleTransport(connectionHelper, _tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory, _fakeRebusTime);
 
             _disposables.Add(transport);
 
@@ -62,5 +63,7 @@ namespace Rebus.Oracle.Tests.Transport
             OracleTestHelper.DropTableAndSequence(_tableName);
             OracleTestHelper.DropProcedure("rebus_dequeue_" + _tableName);
         }
+
+        public void FakeIt(DateTimeOffset fakeTime) => _fakeRebusTime.SetNow(fakeTime);
     }
 }

--- a/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
+++ b/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
@@ -28,7 +28,7 @@ namespace Rebus.Oracle.Tests.Transport
         public ITransport CreateOneWayClient()
         {
             var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-             _tablesToDrop.Add(tableName);
+            _tablesToDrop.Add(tableName);
 
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);

--- a/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
+++ b/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
@@ -13,27 +13,23 @@ namespace Rebus.Oracle.Tests.Transport
 {
     public class OracleTransportFactory : ITransportFactory
     {
-
-         readonly HashSet<string> _tablesToDrop = new HashSet<string>();
+        readonly string _tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
+        readonly HashSet<string> _tablesToDrop = new HashSet<string>();
         readonly List<IDisposable> _disposables = new List<IDisposable>();
 
-
         [TestFixture, Category(Categories.Oracle)]
-        public class OracleTransportBasicSendReceive : BasicSendReceive<OracleTransportFactory> { }
+        public class OracleTransportBasicSendReceive : BasicSendReceive<OracleTransportFactory> 
+        { }
 
         [TestFixture, Category(Categories.Oracle)]
         public class OracleTransportMessageExpiration : MessageExpiration<OracleTransportFactory> { }
 
-
         public ITransport CreateOneWayClient()
         {
-            var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-            _tablesToDrop.Add(tableName);
-
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new OracleTransport(connectionHelper, tableName, null, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new OracleTransport(connectionHelper, _tableName, null, consoleLoggerFactory, asyncTaskFactory);
 
             _disposables.Add(transport);
 
@@ -45,14 +41,10 @@ namespace Rebus.Oracle.Tests.Transport
 
         public ITransport Create(string inputQueueAddress)
         {
-            var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-
-            _tablesToDrop.Add(tableName);
-
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new OracleTransport(connectionHelper, tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new OracleTransport(connectionHelper, _tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
 
             _disposables.Add(transport);
 
@@ -67,8 +59,8 @@ namespace Rebus.Oracle.Tests.Transport
             _disposables.ForEach(d => d.Dispose());
             _disposables.Clear();
 
-            _tablesToDrop.ForEach(OracleTestHelper.DropTableAndSequence);
-            _tablesToDrop.Clear();
+            OracleTestHelper.DropTableAndSequence(_tableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + _tableName);
         }
     }
 }

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransport.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransport.cs
@@ -25,7 +25,6 @@ namespace Rebus.Oracle.Tests.Transport
 
         protected override void SetUp()
         {
-            OracleTestHelper.DropTableAndSequence(_tableName);
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
@@ -37,6 +36,12 @@ namespace Rebus.Oracle.Tests.Transport
             _transport.Initialize();
             _cancellationToken = new CancellationTokenSource().Token;
 
+        }
+
+        protected override void TearDown()
+        {
+            OracleTestHelper.DropTableAndSequence(_tableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + _tableName);
         }
 
         [Test]

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransport.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransport.cs
@@ -18,17 +18,17 @@ namespace Rebus.Oracle.Tests.Transport
     [TestFixture, Category(Categories.Oracle)]
     public class TestOracleTransport : FixtureBase
     {
+        const string QueueName = "input";
         readonly string _tableName = "messages" + TestConfig.Suffix;
         OracleTransport _transport;
-        CancellationToken _cancellationToken;
-        const string QueueName = "input";
+        CancellationToken _cancellationToken;        
 
         protected override void SetUp()
         {
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
-            _transport = new OracleTransport(connectionHelper, _tableName, QueueName, consoleLoggerFactory, asyncTaskFactory);
+            _transport = new OracleTransport(connectionHelper, _tableName, QueueName, consoleLoggerFactory, asyncTaskFactory, new FakeRebusTime());
             _transport.EnsureTableIsCreated();
 
             Using(_transport);
@@ -146,9 +146,8 @@ namespace Rebus.Oracle.Tests.Transport
 
             if (kvpsDifferentThanOne.Any())
             {
-                Assert.Fail(@"Oh no! the following IDs were not received exactly once:
-{0}",
-    string.Join(Environment.NewLine, kvpsDifferentThanOne.Select(kvp => $"   {kvp.Key}: {kvp.Value}")));
+                Assert.Fail("Oh no! the following IDs were not received exactly once:\n{0}",
+                            string.Join(Environment.NewLine, kvpsDifferentThanOne.Select(kvp => $"   {kvp.Key}: {kvp.Value}")));
             }
         }
 

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
@@ -18,7 +18,11 @@ namespace Rebus.Oracle.Tests.Transport
     {
         const string QueueName = "test-ordering";
         const string TableName = "Messages";
-        protected override void SetUp() => OracleTestHelper.DropTableAndSequence(TableName);
+        protected override void TearDown()
+        {
+            OracleTestHelper.DropTableAndSequence(TableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + TableName);
+        } 
 
         [Test]
         public async Task DeliversMessagesByVisibleTimeAndNotBeInsertionTime()

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
@@ -14,7 +14,6 @@ using Rebus.Transport;
 namespace Rebus.Oracle.Tests.Transport
 {
     [TestFixture]
-    [Ignore("This one should probably be enabled some time later")]
     public class TestOracleTransportMessageOrdering : FixtureBase
     {
         const string QueueName = "test-ordering";

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
@@ -18,6 +18,7 @@ namespace Rebus.Oracle.Tests.Transport
     {
         const string QueueName = "test-ordering";
         const string TableName = "Messages";
+
         protected override void TearDown()
         {
             OracleTestHelper.DropTableAndSequence(TableName);
@@ -97,7 +98,8 @@ namespace Rebus.Oracle.Tests.Transport
                 TableName,
                 QueueName,
                 loggerFactory,
-                asyncTaskFactory
+                asyncTaskFactory,
+                new FakeRebusTime()
             );
 
             transport.EnsureTableIsCreated();

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportReceivePerformance.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportReceivePerformance.cs
@@ -25,8 +25,6 @@ namespace Rebus.Oracle.Tests.Transport
 
         protected override void SetUp()
         {
-            OracleTestHelper.DropTableAndSequence(TableName);
-
             _adapter = Using(new BuiltinHandlerActivator());
 
             Configure.With(_adapter)
@@ -38,6 +36,12 @@ namespace Rebus.Oracle.Tests.Transport
                     o.SetMaxParallelism(20);
                 })
                 .Start();
+        }
+
+        protected override void TearDown()
+        {
+            OracleTestHelper.DropTableAndSequence(TableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + TableName);
         }
 
         [TestCase(1000)]

--- a/Rebus.Oracle/Config/OracleConfigurationExtensions.cs
+++ b/Rebus.Oracle/Config/OracleConfigurationExtensions.cs
@@ -8,6 +8,7 @@ using Rebus.Oracle.Subscriptions;
 using Rebus.Oracle.Timeouts;
 using Rebus.Sagas;
 using Rebus.Subscriptions;
+using Rebus.Time;
 using Rebus.Timeouts;
 
 namespace Rebus.Config
@@ -68,7 +69,8 @@ namespace Rebus.Config
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var subscriptionStorage = new OracleTimeoutManager(new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction), tableName, rebusLoggerFactory);
+                var rebusTime = c.Get<IRebusTime>();
+                var subscriptionStorage = new OracleTimeoutManager(new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction), tableName, rebusLoggerFactory, rebusTime);
 
                 if (automaticallyCreateTables)
                 {

--- a/Rebus.Oracle/Config/OracleTransportConfigurationExtensions.cs
+++ b/Rebus.Oracle/Config/OracleTransportConfigurationExtensions.cs
@@ -5,6 +5,7 @@ using Rebus.Oracle.Transport;
 using Rebus.Pipeline;
 using Rebus.Pipeline.Receive;
 using Rebus.Threading;
+using Rebus.Time;
 using Rebus.Timeouts;
 using Rebus.Transport;
 
@@ -43,8 +44,9 @@ namespace Rebus.Config
             {
                 var rebusLoggerFactory = context.Get<IRebusLoggerFactory>();
                 var asyncTaskFactory = context.Get<IAsyncTaskFactory>();
+                var rebusTime = context.Get<IRebusTime>();
                 var connectionProvider = connectionProviderFactory(rebusLoggerFactory);
-                var transport = new OracleTransport(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory);
+                var transport = new OracleTransport(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory, rebusTime);
                 transport.EnsureTableIsCreated();
                 return transport;
             });

--- a/Rebus.Oracle/Oracle/Magic.cs
+++ b/Rebus.Oracle/Oracle/Magic.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Oracle.ManagedDataAccess.Types;
 
 namespace Rebus.Oracle
 {
@@ -22,6 +25,16 @@ namespace Rebus.Oracle
             }
 
             return tableNames;
+        }
+
+        public static DateTimeOffset ToDateTimeOffset(this OracleTimeStampTZ value)
+        {
+            return new DateTimeOffset(value.Value, value.GetTimeZoneOffset());
+        }
+
+        public static OracleTimeStampTZ ToOracleTimeStamp(this DateTimeOffset value)
+        {
+            return new OracleTimeStampTZ(value.DateTime, value.Offset.ToString("c", CultureInfo.InvariantCulture));
         }
     }
 }

--- a/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
+++ b/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
@@ -207,10 +207,11 @@ namespace Rebus.Oracle.Transport
                             $@"
                             delete from {_tableName} 
                             where recipient = :recipient 
-                            and expiration < systimestamp(6)
+                            and expiration < :now
                             ";
                         command.BindByName = true;
                         command.Parameters.Add(new OracleParameter("recipient", OracleDbType.Varchar2, _inputQueueName, ParameterDirection.Input));
+                        command.Parameters.Add(new OracleParameter("now", _rebusTime.Now.ToOracleTimeStamp()));
                         affectedRows = command.ExecuteNonQuery();
                     }
 

--- a/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
+++ b/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
@@ -307,13 +307,15 @@ begin
     WHERE recipient = recipientQueue
             and visible < current_timestamp(6)
             and expiration > current_timestamp(6)          
-    ORDER BY priority ASC, id ASC
+    ORDER BY priority ASC, visible ASC, id ASC
     for update skip locked;
     
     fetch readCursor into messageId;
-    close readCursor;      
-  open output for select * from {_tableName} where id = messageId;
-  delete from {_tableName} where id = messageId;
+    close readCursor;
+
+    open output for select * from {_tableName} where id = messageId;
+
+    delete from {_tableName} where id = messageId;
 END;
 ");
 

--- a/Rebus.Oracle/Rebus.Oracle.csproj
+++ b/Rebus.Oracle/Rebus.Oracle.csproj
@@ -41,8 +41,8 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.12.0-beta3" />
-    <PackageReference Include="Rebus" Version="4.2.1" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.18.3" />
+    <PackageReference Include="Rebus" Version="6.0.0-b11" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />


### PR DESCRIPTION
This is done on top of #19.

I upgraded Rebus dependency to 6.0 and did the migration to `IRebusTime`.

**EDIT**: all 70 tests are green on Oracle 11, including the 4 tests that were flaky on Rebus 5. 🎉 

----

@mookid8000 I have one problem with 5 tests failing with:
```
System.MissingMethodException : Method not found: 'System.Threading.Tasks.Task Rebus.Bus.IBus.SendLocal(System.Object, System.Collections.Generic.Dictionary`2<System.String,System.String>)'.
```
I see `IBus` has a `SendLocal` method now, but no class inside `Rebus.Storage` implements it (the project compiles...) so I'm clueless what's wrong and why this method is dynamically missing.
Any hint? What did you change?