### PR TITLE
Refactor schema creation

### DIFF
--- a/Rebus.Oracle.Tests/DataBus/OracleDataBusStorageFactory.cs
+++ b/Rebus.Oracle.Tests/DataBus/OracleDataBusStorageFactory.cs
@@ -1,0 +1,28 @@
+using System;
+using Rebus.DataBus;
+using Rebus.Logging;
+using Rebus.Oracle.DataBus;
+using Rebus.Tests.Contracts.DataBus;
+
+namespace Rebus.Oracle.Tests.DataBus
+{
+    public class OracleDataBusStorageFactory : IDataBusStorageFactory
+    {        
+        readonly FakeRebusTime _fakeRebusTime = new FakeRebusTime();
+        
+        public IDataBusStorage Create()
+        {
+            var consoleLoggerFactory = new ConsoleLoggerFactory(false);
+            var sqlServerDataBusStorage = new OracleDataBusStorage(OracleTestHelper.ConnectionHelper, "databus", true, consoleLoggerFactory, _fakeRebusTime);
+            sqlServerDataBusStorage.Initialize();
+            return sqlServerDataBusStorage;
+        }
+
+        public void CleanUp()
+        {
+            OracleTestHelper.DropTable("databus");
+        }
+
+        public void FakeIt(DateTimeOffset fakeTime) => _fakeRebusTime.SetNow(fakeTime);
+    }
+}

--- a/Rebus.Oracle.Tests/DataBus/OracleDataBusStorageFactory.cs
+++ b/Rebus.Oracle.Tests/DataBus/OracleDataBusStorageFactory.cs
@@ -13,9 +13,9 @@ namespace Rebus.Oracle.Tests.DataBus
         public IDataBusStorage Create()
         {
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
-            var sqlServerDataBusStorage = new OracleDataBusStorage(OracleTestHelper.ConnectionHelper, "databus", true, consoleLoggerFactory, _fakeRebusTime);
-            sqlServerDataBusStorage.Initialize();
-            return sqlServerDataBusStorage;
+            var storage = new OracleDataBusStorage(OracleTestHelper.ConnectionHelper, "databus", consoleLoggerFactory, _fakeRebusTime);
+            storage.EnsureTableIsCreated();
+            return storage;
         }
 
         public void CleanUp()

--- a/Rebus.Oracle.Tests/DataBus/OracleDataBusStorageTest.cs
+++ b/Rebus.Oracle.Tests/DataBus/OracleDataBusStorageTest.cs
@@ -1,0 +1,8 @@
+using NUnit.Framework;
+using Rebus.Tests.Contracts.DataBus;
+
+namespace Rebus.Oracle.Tests.DataBus
+{
+    [TestFixture]
+    public class SqlServerDataBusStorageTest : GeneralDataBusStorageTests<OracleDataBusStorageFactory> { }
+}

--- a/Rebus.Oracle.Tests/DataBus/TestOracleDataBusLazyRead.cs
+++ b/Rebus.Oracle.Tests/DataBus/TestOracleDataBusLazyRead.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.DataBus;
+using Rebus.Tests.Contracts;
+
+namespace Rebus.Oracle.Tests.DataBus
+{
+    [TestFixture]
+    public class TestSqlServerDataBusLazyRead : FixtureBase
+    {
+        IDataBusStorage _storage;
+        OracleDataBusStorageFactory _factory;
+
+        protected override void SetUp()
+        {
+            _factory = new OracleDataBusStorageFactory();
+            _storage = _factory.Create();
+        }
+
+        protected override void TearDown()
+        {
+            _factory.CleanUp();
+        }
+
+        [TestCase(1024*1024*100)]
+        public async Task ReadingIsLazy(int byteCount)
+        {
+            const string dataId = "known id";
+
+            Console.WriteLine($"Generating {byteCount/(double)(1024*1024):0.00} MB of data...");
+
+            var data = GenerateData(byteCount);
+
+            Console.WriteLine("Saving data...");
+
+            await _storage.Save(dataId, new MemoryStream(data));
+
+            Console.WriteLine("Reading data...");
+
+            var stopwatch = Stopwatch.StartNew();
+            using (var source = await _storage.Read(dataId))
+            using (var destination = new MemoryStream())
+            {
+                var elapsedWhenStreamIsOpen = stopwatch.Elapsed;
+
+                Console.WriteLine($"Opening stream took {elapsedWhenStreamIsOpen.TotalSeconds:0.00} s");
+
+                await source.CopyToAsync(destination);
+
+                var elapsedWhenStreamHasBeenRead = stopwatch.Elapsed;
+
+                Console.WriteLine($"Entire operation took {elapsedWhenStreamHasBeenRead.TotalSeconds:0.00} s");
+
+                var fraction = elapsedWhenStreamHasBeenRead.TotalSeconds/10;
+                Assert.That(elapsedWhenStreamIsOpen.TotalSeconds, Is.LessThan(fraction), 
+                    "Expected time to open stream to be less than 1/10 of the time it takes to read the entire stream");
+            }
+        }
+
+        static byte[] GenerateData(int byteCount)
+        {
+            var buffer = new byte[byteCount];
+            new Random(DateTime.Now.GetHashCode()).NextBytes(buffer);
+            return buffer;
+        }
+    }
+}

--- a/Rebus.Oracle.Tests/DataBus/TestOracleDataBusStorage.cs
+++ b/Rebus.Oracle.Tests/DataBus/TestOracleDataBusStorage.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Logging;
+using Rebus.Oracle.DataBus;
+using Rebus.Tests.Contracts;
+using Rebus.Tests.Contracts.Extensions;
+
+namespace Rebus.Oracle.Tests.DataBus
+{
+    [TestFixture]
+    public class TestSqlServerDataBusStorage : FixtureBase
+    {
+        OracleDataBusStorage _storage;
+
+        protected override void SetUp()
+        {
+            var loggerFactory = new ConsoleLoggerFactory(false);
+            var tableName = TestConfig.GetName("data");
+
+            OracleTestHelper.DropTable(tableName);
+
+            _storage = new OracleDataBusStorage(OracleTestHelper.ConnectionHelper, tableName, true, loggerFactory, new FakeRebusTime());
+            _storage.Initialize();
+        }
+
+        [Test]
+        public async Task CanReadDataInParallel()
+        {
+            var longString = string.Concat(Enumerable.Repeat(@"
+Let me explain something to you. Um, I am not ""Mr.Lebowski"". 
+You're Mr. Lebowski. I'm the Dude. 
+So that's what you call me. 
+You know, that or, uh, His Dudeness, or uh, Duder, or El Duderino if you're not into the whole brevity thing.
+", 100));
+
+            const string dataId = "known-id";
+
+            using (var source = new MemoryStream(Encoding.UTF8.GetBytes(longString)))
+            {
+                await _storage.Save(dataId, source);
+            }
+
+            var caughtExceptions = new ConcurrentQueue<Exception>();
+
+            Console.WriteLine("Reading the data many times in parallel");
+            var threads = Enumerable.Range(0, 10)
+                .Select(i =>
+                {
+                    var thread = new Thread(() =>
+                    {
+                        100.Times(() =>
+                        {
+                            Console.Write(".");
+                            try
+                            {
+                                using (var source = _storage.Read(dataId).Result)
+                                using (var destination = new MemoryStream())
+                                {
+                                    source.CopyTo(destination);
+                                }
+                            }
+                            catch (Exception exception)
+                            {
+                                caughtExceptions.Enqueue(exception);
+                            }
+                        });
+                    });
+
+                    return thread;
+                })
+                .ToList();
+
+            Console.WriteLine("Starting threads");
+            threads.ForEach(t => t.Start());
+
+            Console.WriteLine("Waiting for them to finish");
+            threads.ForEach(t => t.Join());
+
+            Console.WriteLine("Finished :)");
+
+            if (caughtExceptions.Count > 0)
+            {
+                Assert.Fail($@"Caught {caughtExceptions.Count} exceptions - here's the first 5:
+{string.Join(Environment.NewLine + Environment.NewLine, caughtExceptions.Take(5))}");
+            }
+
+        }
+    }
+}

--- a/Rebus.Oracle.Tests/DataBus/TestOracleDataBusStorage.cs
+++ b/Rebus.Oracle.Tests/DataBus/TestOracleDataBusStorage.cs
@@ -22,8 +22,8 @@ namespace Rebus.Oracle.Tests.DataBus
         protected override void SetUp()
         {
             var loggerFactory = new ConsoleLoggerFactory(false);
-            _storage = new OracleDataBusStorage(OracleTestHelper.ConnectionHelper, tableName, true, loggerFactory, new FakeRebusTime());
-            _storage.Initialize();
+            _storage = new OracleDataBusStorage(OracleTestHelper.ConnectionHelper, tableName, loggerFactory, new FakeRebusTime());
+            _storage.EnsureTableIsCreated();
         }
 
         protected override void TearDown()

--- a/Rebus.Oracle.Tests/DataBus/TestOracleDataBusStorage.cs
+++ b/Rebus.Oracle.Tests/DataBus/TestOracleDataBusStorage.cs
@@ -16,17 +16,19 @@ namespace Rebus.Oracle.Tests.DataBus
     [TestFixture]
     public class TestSqlServerDataBusStorage : FixtureBase
     {
+        readonly string tableName = TestConfig.GetName("data");
         OracleDataBusStorage _storage;
 
         protected override void SetUp()
         {
             var loggerFactory = new ConsoleLoggerFactory(false);
-            var tableName = TestConfig.GetName("data");
-
-            OracleTestHelper.DropTable(tableName);
-
             _storage = new OracleDataBusStorage(OracleTestHelper.ConnectionHelper, tableName, true, loggerFactory, new FakeRebusTime());
             _storage.Initialize();
+        }
+
+        protected override void TearDown()
+        {
+            OracleTestHelper.DropTable(tableName);
         }
 
         [Test]
@@ -40,8 +42,10 @@ You know, that or, uh, His Dudeness, or uh, Duder, or El Duderino if you're not 
 ", 100));
 
             const string dataId = "known-id";
+            var bytes = Encoding.UTF8.GetBytes(longString);
+            int length = bytes.Length;
 
-            using (var source = new MemoryStream(Encoding.UTF8.GetBytes(longString)))
+            using (var source = new MemoryStream(bytes))
             {
                 await _storage.Save(dataId, source);
             }
@@ -63,6 +67,7 @@ You know, that or, uh, His Dudeness, or uh, Duder, or El Duderino if you're not 
                                 using (var destination = new MemoryStream())
                                 {
                                     source.CopyTo(destination);
+                                    Assert.AreEqual(length, destination.Length);
                                 }
                             }
                             catch (Exception exception)

--- a/Rebus.Oracle.Tests/FakeRebusTime.cs
+++ b/Rebus.Oracle.Tests/FakeRebusTime.cs
@@ -1,0 +1,14 @@
+using System;
+using Rebus.Time;
+
+namespace Rebus.Oracle.Tests
+{
+    class FakeRebusTime : IRebusTime
+    {
+        Func<DateTimeOffset> _nowFactory = () => DateTimeOffset.Now;
+
+        public DateTimeOffset Now => _nowFactory();
+
+        public void SetNow(DateTimeOffset fakeTime) => _nowFactory = () => fakeTime;
+    }
+}

--- a/Rebus.Oracle.Tests/Integration/TestOracleAllTheWay.cs
+++ b/Rebus.Oracle.Tests/Integration/TestOracleAllTheWay.cs
@@ -22,8 +22,6 @@ namespace Rebus.Oracle.Tests.Integration
 
         protected override void SetUp()
         {
-            DropTables();
-
             _activator = new BuiltinHandlerActivator();
 
             Using(_activator);
@@ -40,12 +38,8 @@ namespace Rebus.Oracle.Tests.Integration
 
         protected override void TearDown()
         {
-            DropTables();
-        }
-
-        static void DropTables()
-        {
             OracleTestHelper.DropTableAndSequence("transports");
+            OracleTestHelper.DropProcedure("rebus_dequeue_transports");
         }
 
         [Test]

--- a/Rebus.Oracle.Tests/OracleTestHelper.cs
+++ b/Rebus.Oracle.Tests/OracleTestHelper.cs
@@ -16,44 +16,35 @@ namespace Rebus.Oracle.Tests
 
         public static OracleConnectionHelper ConnectionHelper => OracleConnectionHelper;
 
-        public static void DropTableAndSequence(string tableName)
+        static void DropTable(string tableName, bool dropSequence)
         {
             using (var connection = OracleConnectionHelper.GetConnection())
+            using (var command = connection.CreateCommand())
             {
-                using (var comand = connection.CreateCommand())
+                try
                 {
-                    comand.CommandText = $@"drop table {tableName}";
-
-                    try
-                    {
-                        comand.ExecuteNonQuery();
-
-                        Console.WriteLine("Dropped oracle table '{0}'", tableName);
-                    }
-                    catch (OracleException exception) when (exception.Number == TableDoesNotExist)
-                    {
-                    }
+                    command.CommandText = "drop table " + tableName;
+                    command.ExecuteNonQuery();
+                    Console.WriteLine($"Dropped oracle table '{tableName}'");                    
                 }
-
-                using (var comand = connection.CreateCommand())
+                catch (OracleException exception) when (exception.Number == TableDoesNotExist)
+                { }
+                
+                try
                 {
-                    comand.CommandText = $@"drop sequence {tableName}_SEQ";
-
-                    try
-                    {
-                        comand.ExecuteNonQuery();
-
-                        Console.WriteLine("Dropped oracle sequence '{0}_SEQ'", tableName);
-                    }
-                    catch (OracleException exception) when (exception.Number ==SequenceDoesNotExist)
-                    {
-                    }
+                    command.CommandText = $"drop sequence {tableName}_SEQ";
+                    command.ExecuteNonQuery();
+                    Console.WriteLine("Dropped oracle sequence '{0}_SEQ'", tableName);
                 }
-
+                catch (OracleException exception) when (exception.Number == SequenceDoesNotExist)
+                { }
 
                 connection.Complete();
             }
         }
+
+        public static void DropTable(string tableName) => DropTable(tableName, dropSequence: false);
+        public static void DropTableAndSequence(string tableName) => DropTable(tableName, dropSequence: true);
 
         static string GetConnectionStringForDatabase(string databaseName)
         {

--- a/Rebus.Oracle.Tests/OracleTestHelper.cs
+++ b/Rebus.Oracle.Tests/OracleTestHelper.cs
@@ -8,6 +8,7 @@ namespace Rebus.Oracle.Tests
     {
         const int TableDoesNotExist = 942;
         const int SequenceDoesNotExist = 2289;
+        const int ProcedureDoesNotExist = 4043;
         static readonly OracleConnectionHelper OracleConnectionHelper = new OracleConnectionHelper(ConnectionString);
 
         public static string DatabaseName => $"rebus2_test_{TestConfig.Suffix}".TrimEnd('_');
@@ -45,6 +46,24 @@ namespace Rebus.Oracle.Tests
 
         public static void DropTable(string tableName) => DropTable(tableName, dropSequence: false);
         public static void DropTableAndSequence(string tableName) => DropTable(tableName, dropSequence: true);
+
+        public static void DropProcedure(string procedureName)
+        {
+            using (var connection = OracleConnectionHelper.GetConnection())
+            using (var command = connection.CreateCommand())
+            {
+                try
+                {
+                    command.CommandText = "drop procedure " + procedureName;
+                    command.ExecuteNonQuery();
+                    Console.WriteLine($"Dropped oracle procedure '{procedureName}'");                    
+                }
+                catch (OracleException exception) when (exception.Number == ProcedureDoesNotExist)
+                { }
+
+                connection.Complete();
+            }
+        }
 
         static string GetConnectionStringForDatabase(string databaseName)
         {

--- a/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
+++ b/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.14.0" />
     <PackageReference Include="rebus" Version="6.0.0-b11" />
-    <PackageReference Include="rebus.tests.contracts" Version="6.0.0-b06" />
+    <PackageReference Include="rebus.tests.contracts" Version="6.0.0-b11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
   </ItemGroup>
 </Project>

--- a/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
+++ b/Rebus.Oracle.Tests/Rebus.Oracle.Tests.csproj
@@ -28,10 +28,10 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rebus.Oracle\Rebus.Oracle.csproj" />
-    <PackageReference Include="nunit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="rebus" Version="4.2.1" />
-    <PackageReference Include="rebus.tests.contracts" Version="4.0.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.14.0" />
+    <PackageReference Include="rebus" Version="6.0.0-b11" />
+    <PackageReference Include="rebus.tests.contracts" Version="6.0.0-b06" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
   </ItemGroup>
 </Project>

--- a/Rebus.Oracle.Tests/Sagas/OracleSagaSnapshotTest.cs
+++ b/Rebus.Oracle.Tests/Sagas/OracleSagaSnapshotTest.cs
@@ -4,5 +4,12 @@ using Rebus.Tests.Contracts.Sagas;
 namespace Rebus.Oracle.Tests.Sagas
 {
     [TestFixture, Category(TestCategory.Oracle)]
-    public class OracleSagaSnapshotTest : SagaSnapshotStorageTest<OracleSnapshotStorageFactory> { }
+    public class OracleSagaSnapshotTest : SagaSnapshotStorageTest<OracleSnapshotStorageFactory> 
+    { 
+        protected override void TearDown()
+        {
+            base.TearDown();
+            OracleTestHelper.DropTable(OracleSnapshotStorageFactory.TableName);
+        }
+    }
 }

--- a/Rebus.Oracle.Tests/Sagas/OracleSagaStorageFactory.cs
+++ b/Rebus.Oracle.Tests/Sagas/OracleSagaStorageFactory.cs
@@ -7,12 +7,6 @@ namespace Rebus.Oracle.Tests.Sagas
 {
     public class OracleSagaStorageFactory : ISagaStorageFactory
     {
-        public OracleSagaStorageFactory()
-        {
-            OracleTestHelper.DropTableAndSequence("saga_index");
-            OracleTestHelper.DropTableAndSequence("saga_data");
-        }
-
         public ISagaStorage GetSagaStorage()
         {
             var OracleSagaStorage = new OracleSqlSagaStorage(OracleTestHelper.ConnectionHelper, "saga_data", "saga_index", new ConsoleLoggerFactory(false));
@@ -22,8 +16,8 @@ namespace Rebus.Oracle.Tests.Sagas
 
         public void CleanUp()
         {
-            //OracleTestHelper.DropTable("saga_index");
-            //OracleTestHelper.DropTable("saga_data");
+            OracleTestHelper.DropTable("saga_index");
+            OracleTestHelper.DropTable("saga_data");
         }
     }
 }

--- a/Rebus.Oracle.Tests/Sagas/OracleSnapshotStorageFactory.cs
+++ b/Rebus.Oracle.Tests/Sagas/OracleSnapshotStorageFactory.cs
@@ -9,12 +9,7 @@ namespace Rebus.Oracle.Tests.Sagas
 {
     public class OracleSnapshotStorageFactory : ISagaSnapshotStorageFactory
     {
-        const string TableName = "SagaSnaps";
-
-        public OracleSnapshotStorageFactory()
-        {
-            OracleTestHelper.DropTableAndSequence(TableName);
-        }
+        internal const string TableName = "SagaSnaps";
 
         public ISagaSnapshotStorage Create()
         {

--- a/Rebus.Oracle.Tests/Timeouts/TestOracleTimeoutManager.cs
+++ b/Rebus.Oracle.Tests/Timeouts/TestOracleTimeoutManager.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using Rebus.Logging;
 using Rebus.Oracle.Timeouts;
 using Rebus.Tests.Contracts.Timeouts;
@@ -13,16 +14,13 @@ namespace Rebus.Oracle.Tests.Timeouts
 
     public class OracleTimeoutManagerFactory : ITimeoutManagerFactory
     {
-        public OracleTimeoutManagerFactory()
-        {
-            OracleTestHelper.DropTableAndSequence("timeouts");
-        }
+        readonly FakeRebusTime _fakeRebusTime = new FakeRebusTime();
 
         public ITimeoutManager Create()
         {
-            var OracleTimeoutManager = new OracleTimeoutManager(OracleTestHelper.ConnectionHelper, "timeouts", new ConsoleLoggerFactory(false));
-            OracleTimeoutManager.EnsureTableIsCreated();
-            return OracleTimeoutManager;
+            var oracleTimeoutManager = new OracleTimeoutManager(OracleTestHelper.ConnectionHelper, "timeouts", new ConsoleLoggerFactory(false), _fakeRebusTime);
+            oracleTimeoutManager.EnsureTableIsCreated();
+            return oracleTimeoutManager;
         }
 
         public void Cleanup()
@@ -30,10 +28,11 @@ namespace Rebus.Oracle.Tests.Timeouts
             OracleTestHelper.DropTableAndSequence("timeouts");
         }
 
+        public void FakeIt(DateTimeOffset fakeTime) => _fakeRebusTime.SetNow(fakeTime);
+
         public string GetDebugInfo()
         {
             return "could not provide debug info for this particular timeout manager.... implement if needed :)";
         }
     }
-
 }

--- a/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
+++ b/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
@@ -14,22 +14,23 @@ namespace Rebus.Oracle.Tests.Transport
     public class OracleTransportFactory : ITransportFactory
     {
         readonly string _tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-        readonly HashSet<string> _tablesToDrop = new HashSet<string>();
         readonly List<IDisposable> _disposables = new List<IDisposable>();
+        readonly FakeRebusTime _fakeRebusTime = new FakeRebusTime();
 
         [TestFixture, Category(Categories.Oracle)]
         public class OracleTransportBasicSendReceive : BasicSendReceive<OracleTransportFactory> 
         { }
 
         [TestFixture, Category(Categories.Oracle)]
-        public class OracleTransportMessageExpiration : MessageExpiration<OracleTransportFactory> { }
+        public class OracleTransportMessageExpiration : MessageExpiration<OracleTransportFactory> 
+        { }
 
         public ITransport CreateOneWayClient()
         {
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new OracleTransport(connectionHelper, _tableName, null, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new OracleTransport(connectionHelper, _tableName, null, consoleLoggerFactory, asyncTaskFactory, _fakeRebusTime);
 
             _disposables.Add(transport);
 
@@ -44,7 +45,7 @@ namespace Rebus.Oracle.Tests.Transport
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new OracleTransport(connectionHelper, _tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new OracleTransport(connectionHelper, _tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory, _fakeRebusTime);
 
             _disposables.Add(transport);
 
@@ -62,5 +63,7 @@ namespace Rebus.Oracle.Tests.Transport
             OracleTestHelper.DropTableAndSequence(_tableName);
             OracleTestHelper.DropProcedure("rebus_dequeue_" + _tableName);
         }
+
+        public void FakeIt(DateTimeOffset fakeTime) => _fakeRebusTime.SetNow(fakeTime);
     }
 }

--- a/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
+++ b/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
@@ -28,7 +28,7 @@ namespace Rebus.Oracle.Tests.Transport
         public ITransport CreateOneWayClient()
         {
             var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-             _tablesToDrop.Add(tableName);
+            _tablesToDrop.Add(tableName);
 
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);

--- a/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
+++ b/Rebus.Oracle.Tests/Transport/OracleTransportFactory.cs
@@ -13,27 +13,23 @@ namespace Rebus.Oracle.Tests.Transport
 {
     public class OracleTransportFactory : ITransportFactory
     {
-
-         readonly HashSet<string> _tablesToDrop = new HashSet<string>();
+        readonly string _tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
+        readonly HashSet<string> _tablesToDrop = new HashSet<string>();
         readonly List<IDisposable> _disposables = new List<IDisposable>();
 
-
         [TestFixture, Category(Categories.Oracle)]
-        public class OracleTransportBasicSendReceive : BasicSendReceive<OracleTransportFactory> { }
+        public class OracleTransportBasicSendReceive : BasicSendReceive<OracleTransportFactory> 
+        { }
 
         [TestFixture, Category(Categories.Oracle)]
         public class OracleTransportMessageExpiration : MessageExpiration<OracleTransportFactory> { }
 
-
         public ITransport CreateOneWayClient()
         {
-            var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-            _tablesToDrop.Add(tableName);
-
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new OracleTransport(connectionHelper, tableName, null, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new OracleTransport(connectionHelper, _tableName, null, consoleLoggerFactory, asyncTaskFactory);
 
             _disposables.Add(transport);
 
@@ -45,14 +41,10 @@ namespace Rebus.Oracle.Tests.Transport
 
         public ITransport Create(string inputQueueAddress)
         {
-            var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
-
-            _tablesToDrop.Add(tableName);
-
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new OracleTransport(connectionHelper, tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new OracleTransport(connectionHelper, _tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
 
             _disposables.Add(transport);
 
@@ -67,8 +59,8 @@ namespace Rebus.Oracle.Tests.Transport
             _disposables.ForEach(d => d.Dispose());
             _disposables.Clear();
 
-            _tablesToDrop.ForEach(OracleTestHelper.DropTableAndSequence);
-            _tablesToDrop.Clear();
+            OracleTestHelper.DropTableAndSequence(_tableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + _tableName);
         }
     }
 }

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransport.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransport.cs
@@ -25,7 +25,6 @@ namespace Rebus.Oracle.Tests.Transport
 
         protected override void SetUp()
         {
-            OracleTestHelper.DropTableAndSequence(_tableName);
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
@@ -37,6 +36,12 @@ namespace Rebus.Oracle.Tests.Transport
             _transport.Initialize();
             _cancellationToken = new CancellationTokenSource().Token;
 
+        }
+
+        protected override void TearDown()
+        {
+            OracleTestHelper.DropTableAndSequence(_tableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + _tableName);
         }
 
         [Test]

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransport.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransport.cs
@@ -18,17 +18,17 @@ namespace Rebus.Oracle.Tests.Transport
     [TestFixture, Category(Categories.Oracle)]
     public class TestOracleTransport : FixtureBase
     {
+        const string QueueName = "input";
         readonly string _tableName = "messages" + TestConfig.Suffix;
         OracleTransport _transport;
-        CancellationToken _cancellationToken;
-        const string QueueName = "input";
+        CancellationToken _cancellationToken;        
 
         protected override void SetUp()
         {
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
             var connectionHelper = new OracleConnectionHelper(OracleTestHelper.ConnectionString);
-            _transport = new OracleTransport(connectionHelper, _tableName, QueueName, consoleLoggerFactory, asyncTaskFactory);
+            _transport = new OracleTransport(connectionHelper, _tableName, QueueName, consoleLoggerFactory, asyncTaskFactory, new FakeRebusTime());
             _transport.EnsureTableIsCreated();
 
             Using(_transport);
@@ -146,9 +146,8 @@ namespace Rebus.Oracle.Tests.Transport
 
             if (kvpsDifferentThanOne.Any())
             {
-                Assert.Fail(@"Oh no! the following IDs were not received exactly once:
-{0}",
-    string.Join(Environment.NewLine, kvpsDifferentThanOne.Select(kvp => $"   {kvp.Key}: {kvp.Value}")));
+                Assert.Fail("Oh no! the following IDs were not received exactly once:\n{0}",
+                            string.Join(Environment.NewLine, kvpsDifferentThanOne.Select(kvp => $"   {kvp.Key}: {kvp.Value}")));
             }
         }
 

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
@@ -18,7 +18,11 @@ namespace Rebus.Oracle.Tests.Transport
     {
         const string QueueName = "test-ordering";
         const string TableName = "Messages";
-        protected override void SetUp() => OracleTestHelper.DropTableAndSequence(TableName);
+        protected override void TearDown()
+        {
+            OracleTestHelper.DropTableAndSequence(TableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + TableName);
+        } 
 
         [Test]
         public async Task DeliversMessagesByVisibleTimeAndNotBeInsertionTime()

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
@@ -14,7 +14,6 @@ using Rebus.Transport;
 namespace Rebus.Oracle.Tests.Transport
 {
     [TestFixture]
-    [Ignore("This one should probably be enabled some time later")]
     public class TestOracleTransportMessageOrdering : FixtureBase
     {
         const string QueueName = "test-ordering";

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportMessageOrdering.cs
@@ -18,6 +18,7 @@ namespace Rebus.Oracle.Tests.Transport
     {
         const string QueueName = "test-ordering";
         const string TableName = "Messages";
+
         protected override void TearDown()
         {
             OracleTestHelper.DropTableAndSequence(TableName);
@@ -97,7 +98,8 @@ namespace Rebus.Oracle.Tests.Transport
                 TableName,
                 QueueName,
                 loggerFactory,
-                asyncTaskFactory
+                asyncTaskFactory,
+                new FakeRebusTime()
             );
 
             transport.EnsureTableIsCreated();

--- a/Rebus.Oracle.Tests/Transport/TestOracleTransportReceivePerformance.cs
+++ b/Rebus.Oracle.Tests/Transport/TestOracleTransportReceivePerformance.cs
@@ -25,8 +25,6 @@ namespace Rebus.Oracle.Tests.Transport
 
         protected override void SetUp()
         {
-            OracleTestHelper.DropTableAndSequence(TableName);
-
             _adapter = Using(new BuiltinHandlerActivator());
 
             Configure.With(_adapter)
@@ -38,6 +36,12 @@ namespace Rebus.Oracle.Tests.Transport
                     o.SetMaxParallelism(20);
                 })
                 .Start();
+        }
+
+        protected override void TearDown()
+        {
+            OracleTestHelper.DropTableAndSequence(TableName);
+            OracleTestHelper.DropProcedure("rebus_dequeue_" + TableName);
         }
 
         [TestCase(1000)]

--- a/Rebus.Oracle/Config/OracleConfigurationExtensions.cs
+++ b/Rebus.Oracle/Config/OracleConfigurationExtensions.cs
@@ -8,6 +8,7 @@ using Rebus.Oracle.Subscriptions;
 using Rebus.Oracle.Timeouts;
 using Rebus.Sagas;
 using Rebus.Subscriptions;
+using Rebus.Time;
 using Rebus.Timeouts;
 
 namespace Rebus.Config
@@ -68,7 +69,8 @@ namespace Rebus.Config
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var subscriptionStorage = new OracleTimeoutManager(new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction), tableName, rebusLoggerFactory);
+                var rebusTime = c.Get<IRebusTime>();
+                var subscriptionStorage = new OracleTimeoutManager(new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction), tableName, rebusLoggerFactory, rebusTime);
 
                 if (automaticallyCreateTables)
                 {

--- a/Rebus.Oracle/Config/OracleDataBusConfigurationExtensions.cs
+++ b/Rebus.Oracle/Config/OracleDataBusConfigurationExtensions.cs
@@ -16,7 +16,7 @@ namespace Rebus.Config
         /// <summary>
         /// Configures the data bus to store data in a central Oracle table
         /// </summary>
-        public static void StoreInOracle(this StandardConfigurer<IDataBusStorage> configurer, string connectionString, string tableName, Action<OracleConnection> additionalConnectionSetup = null, bool automaticallyCreateTables = true, bool enlistInAmbientTransaction = false)
+        public static void StoreInOracle(this StandardConfigurer<IDataBusStorage> configurer, string connectionString, string tableName, Action<OracleConnection> additionalConnectionSetup = null, bool enlistInAmbientTransaction = false, bool automaticallyCreateTables = true)
         {
             if (configurer == null) throw new ArgumentNullException(nameof(configurer));
             if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
@@ -27,7 +27,9 @@ namespace Rebus.Config
                 var loggerFactory = c.Get<IRebusLoggerFactory>();
                 var rebusTime = c.Get<IRebusTime>();
                 var connectionHelper = new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction);
-                return new OracleDataBusStorage(connectionHelper, tableName, automaticallyCreateTables, loggerFactory, rebusTime);
+                var storage = new OracleDataBusStorage(connectionHelper, tableName, loggerFactory, rebusTime);
+                if (automaticallyCreateTables) storage.EnsureTableIsCreated();
+                return storage;
             });
         }
     }

--- a/Rebus.Oracle/Config/OracleDataBusConfigurationExtensions.cs
+++ b/Rebus.Oracle/Config/OracleDataBusConfigurationExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using Oracle.ManagedDataAccess.Client;
+using Rebus.DataBus;
+using Rebus.Logging;
+using Rebus.Oracle;
+using Rebus.Oracle.DataBus;
+using Rebus.Time;
+
+namespace Rebus.Config
+{
+    /// <summary>
+    /// Configuration extensions for Oracle data bus
+    /// </summary>
+    public static class OracleDataBusConfigurationExtensions
+    {
+        /// <summary>
+        /// Configures the data bus to store data in a central Oracle table
+        /// </summary>
+        public static void StoreInOracle(this StandardConfigurer<IDataBusStorage> configurer, string connectionString, string tableName, Action<OracleConnection> additionalConnectionSetup = null, bool automaticallyCreateTables = true, bool enlistInAmbientTransaction = false)
+        {
+            if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+            if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
+            if (tableName == null) throw new ArgumentNullException(nameof(tableName));
+
+            configurer.Register(c =>
+            {
+                var loggerFactory = c.Get<IRebusLoggerFactory>();
+                var rebusTime = c.Get<IRebusTime>();
+                var connectionHelper = new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction);
+                return new OracleDataBusStorage(connectionHelper, tableName, automaticallyCreateTables, loggerFactory, rebusTime);
+            });
+        }
+    }
+}

--- a/Rebus.Oracle/Config/OracleTransportConfigurationExtensions.cs
+++ b/Rebus.Oracle/Config/OracleTransportConfigurationExtensions.cs
@@ -5,6 +5,7 @@ using Rebus.Oracle.Transport;
 using Rebus.Pipeline;
 using Rebus.Pipeline.Receive;
 using Rebus.Threading;
+using Rebus.Time;
 using Rebus.Timeouts;
 using Rebus.Transport;
 
@@ -43,8 +44,9 @@ namespace Rebus.Config
             {
                 var rebusLoggerFactory = context.Get<IRebusLoggerFactory>();
                 var asyncTaskFactory = context.Get<IAsyncTaskFactory>();
+                var rebusTime = context.Get<IRebusTime>();
                 var connectionProvider = connectionProviderFactory(rebusLoggerFactory);
-                var transport = new OracleTransport(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory);
+                var transport = new OracleTransport(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory, rebusTime);
                 transport.EnsureTableIsCreated();
                 return transport;
             });

--- a/Rebus.Oracle/Oracle/DataBus/OracleDataBusStorage.cs
+++ b/Rebus.Oracle/Oracle/DataBus/OracleDataBusStorage.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Oracle.ManagedDataAccess.Client;
+using Rebus.Bus;
+using Rebus.DataBus;
+using Rebus.Exceptions;
+using Rebus.Logging;
+using Rebus.Serialization;
+using Rebus.Time;
+// ReSharper disable SimplifyLinqExpression
+
+namespace Rebus.Oracle.DataBus
+{
+    /// <summary>
+    /// Implementation of <see cref="IDataBusStorage"/> that uses Oracle to store data
+    /// </summary>
+    public class OracleDataBusStorage : IDataBusStorage, IInitializable
+    {
+        static readonly Encoding TextEncoding = Encoding.UTF8;
+        readonly DictionarySerializer _dictionarySerializer = new DictionarySerializer();
+        readonly OracleConnectionHelper _connectionHelper;
+        readonly string _tableName;
+        readonly bool _ensureTableIsCreated;
+        readonly ILog _log;
+        readonly IRebusTime _rebusTime;
+
+        /// <summary>
+        /// Creates the data storage
+        /// </summary>
+        public OracleDataBusStorage(OracleConnectionHelper connectionHelper, string tableName, bool ensureTableIsCreated, IRebusLoggerFactory rebusLoggerFactory, IRebusTime rebusTime)
+        {
+            if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
+            _connectionHelper = connectionHelper ?? throw new ArgumentNullException(nameof(connectionHelper));
+            _tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
+            _ensureTableIsCreated = ensureTableIsCreated;
+            _log = rebusLoggerFactory.GetLogger<OracleDataBusStorage>();
+            _rebusTime = rebusTime ?? throw new ArgumentNullException(nameof(rebusTime));
+        }
+
+        /// <summary>
+        /// Initializes the SQL Server data storage.
+        /// Will create the data table, unless this has been explicitly turned off when configuring the data storage
+        /// </summary>
+        public void Initialize()
+        {
+            if (!_ensureTableIsCreated) return;
+
+            try
+            {
+                EnsureTableIsCreated();
+            }
+            catch
+            {
+                // if it failed because of a collision between another thread doing the same thing, just try again once:
+                EnsureTableIsCreated();
+            }
+        }
+
+        void EnsureTableIsCreated()
+        {
+            using (var connection = _connectionHelper.GetConnection())
+            {
+                if (connection.GetTableNames().Contains(_tableName, StringComparer.OrdinalIgnoreCase))
+                {
+                    _log.Info("Database already contains a table named {tableName} - will not create anything", _tableName);
+                    return;
+                }
+
+                _log.Info("Creating data bus table {tableName}", _tableName);
+
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = $@"
+CREATE TABLE {_tableName} (
+    id VARCHAR2(200) PRIMARY KEY,
+    meta BLOB,
+    data BLOB NOT NULL,
+    creationTime TIMESTAMP WITH TIME ZONE NOT NULL,
+    lastReadTime TIMESTAMP WITH TIME ZONE
+)";
+                    try
+                    {
+                        command.ExecuteNonQuery();
+                    }
+                    catch (OracleException exception)
+                    {
+                        throw new RebusApplicationException(exception, "Error executing SQL command\n" + command.CommandText);
+                    }
+                }
+
+                // Note: calling connection.Complete() is not required as Oracle DDL is not transactional
+            }
+        }
+
+        /// <summary>
+        /// Saves the data from the given source stream under the given ID
+        /// </summary>
+        public Task Save(string id, Stream source, Dictionary<string, string> metadata = null)
+        {
+            try
+            {
+                using (var connection = _connectionHelper.GetConnection())
+                {
+                    using (var blob = connection.CreateBlob())
+                    {
+                        source.CopyTo(blob);
+
+                        using (var command = connection.CreateCommand())
+                        {
+                            var metadataBytes = metadata == null ? 
+                                null : 
+                                TextEncoding.GetBytes(_dictionarySerializer.SerializeToString(metadata));
+
+                            command.CommandText = $"INSERT INTO {_tableName} (id, meta, data, creationTime) VALUES (:id, :meta, :data, :now)";
+                            command.BindByName = true;
+                            command.Parameters.Add("id", id);
+                            command.Parameters.Add("meta", (object)metadataBytes ?? DBNull.Value);
+                            command.Parameters.Add("data", blob);
+                            command.Parameters.Add("now", _rebusTime.Now.ToOracleTimeStamp());
+
+                            command.ExecuteNonQuery();
+                        }
+                    }
+                    
+                    connection.Complete();
+                    return Task.CompletedTask;
+                }
+            }
+            catch (Exception exception)
+            {
+                throw new RebusApplicationException(exception, $"Could not save data with ID {id}");
+            }
+        }
+
+        /// <summary>
+        /// Opens the data stored under the given ID for reading
+        /// </summary>
+        public Task<Stream> Read(string id)
+        {
+            try
+            {
+                // update last read time quickly
+                UpdateLastReadTime(id);
+
+                OracleDbConnection connection = null;
+                OracleCommand command = null;
+                OracleDataReader reader = null;
+
+                try
+                {
+                    connection = _connectionHelper.GetConnection();
+
+                    command = connection.CreateCommand();
+                    command.CommandText = $"SELECT data FROM {_tableName} WHERE id = :id";
+                    command.Parameters.Add("id", id);
+                    command.InitialLOBFetchSize = 4000;
+
+                    reader = command.ExecuteReader(CommandBehavior.SingleRow);
+
+                    if (!reader.Read())
+                        throw new ArgumentException($"DataBus row with ID {id} not found");
+
+                    var blob = reader.GetOracleBlob(0);
+
+                    return Task.FromResult<Stream>(new StreamWrapper(blob, /* dispose with stream: */ reader, command, connection));
+                }
+                catch
+                {
+                    // if something of the above fails, we did not pass ownership to someone who can dispose it... therefore:
+                    reader?.Dispose();
+                    command?.Dispose();
+                    connection?.Dispose();
+                    throw;
+                }
+            }
+            catch (Exception exception)
+            {
+                // Wrap in AggregateException to comply with Rebus contract. Tests do look for this specific exception type.
+                throw new AggregateException(exception);
+            }
+        }
+
+        void UpdateLastReadTime(string id)
+        {
+            using (var connection = _connectionHelper.GetConnection())
+            {
+                UpdateLastReadTime(id, connection);
+                connection.Complete();
+            }
+        }
+
+        void UpdateLastReadTime(string id, OracleDbConnection connection)
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = $"UPDATE {_tableName} SET lastReadTime = :now WHERE id = :id";
+                command.BindByName = true;
+                command.Parameters.Add("now", _rebusTime.Now.ToOracleTimeStamp());
+                command.Parameters.Add("id", id);
+                command.ExecuteNonQuery();
+            }
+        }
+
+        /// <summary>
+        /// Loads the metadata stored with the given ID
+        /// </summary>
+        public Task<Dictionary<string, string>> ReadMetadata(string id)
+        {
+            try
+            {
+                using (var connection =  _connectionHelper.GetConnection())
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = $"SELECT meta, creationTime, lastReadTime, LENGTHB(data) AS dataLength FROM {_tableName} WHERE id = :id";
+                    command.Parameters.Add("id", id);
+
+                    using (var reader = command.ExecuteReader(CommandBehavior.SingleRow))
+                    {
+                        if (!reader.Read())
+                            throw new ArgumentException($"DataBus row with ID {id} not found");
+
+                        var metaDbValue = reader["meta"];
+                        var dataLength = reader.GetInt64(reader.GetOrdinal("dataLength"));
+                        var creationTime = reader.GetOracleTimeStampTZ(reader.GetOrdinal("creationTime")).ToDateTimeOffset();
+                        var lastReadTimeIndex = reader.GetOrdinal("lastReadTime");
+                        var lastReadTime = reader.IsDBNull(lastReadTimeIndex) ?
+                            (DateTimeOffset?)null :
+                            reader.GetOracleTimeStampTZ(lastReadTimeIndex).ToDateTimeOffset();
+
+                        var metadata = metaDbValue is DBNull ?
+                            new Dictionary<string, string>() :
+                            _dictionarySerializer.DeserializeFromString(TextEncoding.GetString((byte[])metaDbValue));
+
+                        metadata[MetadataKeys.Length] = dataLength.ToString();
+                        metadata[MetadataKeys.SaveTime] = creationTime.ToString("O");
+
+                        if (lastReadTime != null)
+                        {
+                            metadata[MetadataKeys.ReadTime] = lastReadTime.Value.ToString("O");
+                        }
+
+                        return Task.FromResult(metadata);
+                    }
+                }
+            }
+            catch (Exception exception) when (!(exception is ArgumentException))
+            {
+                throw new RebusApplicationException(exception, $"Could not load metadata for data with ID {id}");
+            }
+        }
+    }
+}

--- a/Rebus.Oracle/Oracle/DataBus/StreamWrapper.cs
+++ b/Rebus.Oracle/Oracle/DataBus/StreamWrapper.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+
+namespace Rebus.Oracle.DataBus
+{
+    /// <summary>Wraps a stream and additional resources, disposing them when the stream is disposed</summary>
+    class StreamWrapper : Stream
+    {
+        readonly Stream _innerStream;
+        readonly IDisposable[] _disposables;
+
+        public StreamWrapper(Stream innerStream, params IDisposable[] disposables)
+        {
+            if (innerStream == null) throw new ArgumentNullException(nameof(innerStream));
+            _innerStream = innerStream;
+            _disposables = disposables;
+        }
+
+        public override void Flush() => _innerStream.Flush();
+
+        public override long Seek(long offset, SeekOrigin origin) => _innerStream.Seek(offset, origin);
+
+        public override void SetLength(long value) => _innerStream.SetLength(value);
+
+        public override int Read(byte[] buffer, int offset, int count) => _innerStream.Read(buffer, offset, count);
+
+        public override void Write(byte[] buffer, int offset, int count) => _innerStream.Write(buffer, offset, count);
+
+        public override bool CanRead => _innerStream.CanRead;
+        public override bool CanSeek => _innerStream.CanSeek;
+        public override bool CanWrite => _innerStream.CanWrite;
+        public override long Length => _innerStream.Length;
+
+        public override long Position
+        {
+            get => _innerStream.Position;
+            set => _innerStream.Position = value;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _innerStream.Dispose();
+
+            foreach (var disposable in _disposables)
+            {
+                disposable.Dispose();
+            }            
+        }
+    }
+}

--- a/Rebus.Oracle/Oracle/Magic.cs
+++ b/Rebus.Oracle/Oracle/Magic.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Oracle.ManagedDataAccess.Types;
 
 namespace Rebus.Oracle
 {
@@ -22,6 +25,16 @@ namespace Rebus.Oracle
             }
 
             return tableNames;
+        }
+
+        public static DateTimeOffset ToDateTimeOffset(this OracleTimeStampTZ value)
+        {
+            return new DateTimeOffset(value.Value, value.GetTimeZoneOffset());
+        }
+
+        public static OracleTimeStampTZ ToOracleTimeStamp(this DateTimeOffset value)
+        {
+            return new OracleTimeStampTZ(value.DateTime, value.Offset.ToString("c", CultureInfo.InvariantCulture));
         }
     }
 }

--- a/Rebus.Oracle/Oracle/Magic.cs
+++ b/Rebus.Oracle/Oracle/Magic.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
 using Oracle.ManagedDataAccess.Types;
 
@@ -7,26 +6,6 @@ namespace Rebus.Oracle
 {
     static class OracleMagic
     {
-        public static List<string> GetTableNames(this OracleDbConnection connection)
-        {
-            var tableNames = new List<string>();
-
-            using (var command = connection.CreateCommand())
-            {
-                command.CommandText = "select table_name from USER_TABLES";
-
-                using (var reader = command.ExecuteReader())
-                {
-                    while (reader.Read())
-                    {
-                        tableNames.Add(reader["table_name"].ToString());
-                    }
-                }
-            }
-
-            return tableNames;
-        }
-
         public static DateTimeOffset ToDateTimeOffset(this OracleTimeStampTZ value)
         {
             return new DateTimeOffset(value.Value, value.GetTimeZoneOffset());

--- a/Rebus.Oracle/Oracle/OracleDbConnection.cs
+++ b/Rebus.Oracle/Oracle/OracleDbConnection.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Threading.Tasks;
 using Oracle.ManagedDataAccess.Client;
+using Oracle.ManagedDataAccess.Types;
 
 // ReSharper disable EmptyGeneralCatchClause
 #pragma warning disable 1998
@@ -13,6 +13,7 @@ namespace Rebus.Oracle
     public class OracleDbConnection : IDisposable
     {
         readonly OracleConnection _currentConnection;
+        
         OracleTransaction _currentTransaction;
 
         bool _disposed;
@@ -35,6 +36,11 @@ namespace Rebus.Oracle
             command.Transaction = _currentTransaction;
             return command;
         }
+
+        /// <summary>
+        /// Creates a new blob, associated with the current connection
+        /// </summary>
+        public OracleBlob CreateBlob() => new OracleBlob(_currentConnection);
 
         /// <summary>
         /// Completes the transaction

--- a/Rebus.Oracle/Oracle/OracleDbConnection.cs
+++ b/Rebus.Oracle/Oracle/OracleDbConnection.cs
@@ -18,6 +18,8 @@ namespace Rebus.Oracle
 
         bool _disposed;
 
+        internal OracleConnection Connection => _currentConnection;
+
         /// <summary>
         /// Constructs the wrapper with the given connection and transaction
         /// </summary>

--- a/Rebus.Oracle/Oracle/Sagas/OracleSqlSagaStorage.cs
+++ b/Rebus.Oracle/Oracle/Sagas/OracleSqlSagaStorage.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using Rebus.Extensions;
-using System.Reflection;
 using System.Threading.Tasks;
 using Oracle.ManagedDataAccess.Client;
 using Rebus.Exceptions;
@@ -12,6 +11,7 @@ using Rebus.Logging;
 using Rebus.Oracle.Reflection;
 using Rebus.Sagas;
 using Rebus.Serialization;
+using Rebus.Oracle.Schema;
 
 namespace Rebus.Oracle.Sagas
 {
@@ -24,8 +24,8 @@ namespace Rebus.Oracle.Sagas
 
         readonly ObjectSerializer _objectSerializer = new ObjectSerializer();
         readonly OracleConnectionHelper _connectionHelper;
-        readonly string _dataTableName;
-        readonly string _indexTableName;
+        readonly DbName _dataTable;
+        readonly DbName _indexTable;
         readonly ILog _log;
 
         /// <summary>
@@ -36,78 +36,22 @@ namespace Rebus.Oracle.Sagas
         {
             if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
             _connectionHelper = connectionHelper ?? throw new ArgumentNullException(nameof(connectionHelper));
-            _dataTableName = dataTableName ?? throw new ArgumentNullException(nameof(dataTableName));
-            _indexTableName = indexTableName ?? throw new ArgumentNullException(nameof(indexTableName));
+            _dataTable = new DbName(dataTableName) ?? throw new ArgumentNullException(nameof(dataTableName));
+            _indexTable = new DbName(indexTableName) ?? throw new ArgumentNullException(nameof(indexTableName));
             _log = rebusLoggerFactory.GetLogger<OracleSqlSagaStorage>();
         }
 
         /// <summary>
         /// Checks to see if the configured saga data and saga index table exists. If they both exist, we'll continue, if
-        /// neigther of them exists, we'll try to create them. If one of them exists, we'll throw an error.
+        /// neither of them exists, we'll try to create them. If one of them exists, we'll throw an error.
         /// </summary>
         public void EnsureTablesAreCreated()
         {
             using (var connection = _connectionHelper.GetConnection())
             {
-                var tableNames = connection.GetTableNames().ToHashSet();
-
-                var hasDataTable = tableNames.Any(tableName => _dataTableName.Equals(tableName, StringComparison.InvariantCultureIgnoreCase));
-                var hasIndexTable = tableNames.Any(tableName => _indexTableName.Equals(tableName, StringComparison.InvariantCultureIgnoreCase));
-
-                if (hasDataTable && hasIndexTable)
-                {
-                    return;
-                }
-
-                if (hasDataTable)
-                {
-                    throw new RebusApplicationException(
-                        $"The saga index table '{_indexTableName}' does not exist, so the automatic saga schema generation tried to run - but there was already a table named '{_dataTableName}', which was supposed to be created as the data table");
-                }
-
-                if (hasIndexTable)
-                {
-                    throw new RebusApplicationException(
-                        $"The saga data table '{_dataTableName}' does not exist, so the automatic saga schema generation tried to run - but there was already a table named '{_indexTableName}', which was supposed to be created as the index table");
-                }
-
-                _log.Info(
-                    "Saga tables {tableName} (data) and {tableName} (index) do not exist - they will be created now",
-                    _dataTableName, _indexTableName);
-
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText =
-                        $@"
-                        CREATE TABLE {_dataTableName} (
-                            id RAW(16) NOT NULL,
-                            revision NUMBER(10) NOT NULL,
-                            data BLOB NOT NULL,
-                            CONSTRAINT {_dataTableName}_pk PRIMARY KEY(id)
-                        )";
-
-                    command.ExecuteNonQuery();
-                }
-
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText = $@"
-                        CREATE TABLE {_indexTableName} (
-                            saga_type NVARCHAR2(500) NOT NULL,
-                            key NVARCHAR2(500) NOT NULL,
-                            value NVARCHAR2(2000) NOT NULL,
-                            saga_id RAW(16) NOT NULL,
-                            CONSTRAINT {_indexTableName}_pk PRIMARY KEY(key, value, saga_type)
-                        )";
-                    command.ExecuteNonQuery();
-                }
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText = $@"CREATE INDEX {_indexTableName}_IDX ON {_indexTableName} (saga_id)";
-                    command.ExecuteNonQuery();
-                }
-
-                connection.Complete();
+                if (connection.Connection.CreateRebusSaga(_dataTable, _indexTable))
+                    _log.Info("Saga tables {tableName} (data) and {tableName} (index) do not exist - they will be created now",
+                              _dataTable, _indexTable);
             }
         }
 
@@ -126,7 +70,7 @@ namespace Rebus.Oracle.Sagas
                     {
                         command.CommandText = $@"
                             SELECT s.data 
-                                FROM {_dataTableName} s 
+                                FROM {_dataTable} s 
                                 WHERE s.id = :id 
                             ";
                         command.Parameters.Add("id", OracleDbType.Raw).Value = ToGuid(propertyValue).ToByteArray();
@@ -135,8 +79,8 @@ namespace Rebus.Oracle.Sagas
                     {
                         command.CommandText = $@"
                             SELECT s.data
-                                FROM {_dataTableName} s
-                                JOIN {_indexTableName} i on s.id = i.saga_id 
+                                FROM {_dataTable} s
+                                JOIN {_indexTable} i on s.id = i.saga_id 
                                 WHERE i.saga_type = :saga_type AND i.key = :key AND i.value = :value
                             ";
                         command.BindByName = true;
@@ -212,7 +156,7 @@ namespace Rebus.Oracle.Sagas
                         command.CommandText =
                             $@"
                             INSERT 
-                                INTO {_dataTableName} (id, revision, data) 
+                                INTO {_dataTable} (id, revision, data) 
                                 VALUES (:id, :revision, :data)
                             ";
 
@@ -223,7 +167,7 @@ namespace Rebus.Oracle.Sagas
                         catch (OracleException exception)
                         {
                             throw new ConcurrencyException(exception,
-                                $"Saga data {sagaData.GetType()} with ID {sagaData.Id} in table {_dataTableName} could not be inserted!");
+                                $"Saga data {sagaData.GetType()} with ID {sagaData.Id} in table {_dataTable} could not be inserted!");
                         }
                     }
 
@@ -266,7 +210,7 @@ namespace Rebus.Oracle.Sagas
                     using (var command = connection.CreateCommand())
                     {
                         command.BindByName = true;
-                        command.CommandText = $@"DELETE FROM {_indexTableName} WHERE saga_id = :id";
+                        command.CommandText = $@"DELETE FROM {_indexTable} WHERE saga_id = :id";
                         command.Parameters.Add("id", OracleDbType.Raw).Value = sagaData.Id;
                         command.ExecuteNonQuery();
                     }
@@ -282,7 +226,7 @@ namespace Rebus.Oracle.Sagas
 
                         command.CommandText =
                             $@"
-                            UPDATE {_dataTableName} 
+                            UPDATE {_dataTable} 
                                 SET data = :data, revision = :next_revision 
                                 WHERE id = :id AND revision = :current_revision
                             ";
@@ -328,7 +272,7 @@ namespace Rebus.Oracle.Sagas
                         command.CommandText =
                             $@"
                             DELETE 
-                                FROM {_dataTableName} 
+                                FROM {_dataTable} 
                                 WHERE id = :id AND revision = :current_revision
                             ";
 
@@ -349,7 +293,7 @@ namespace Rebus.Oracle.Sagas
                         command.CommandText =
                             $@"
                             DELETE 
-                                FROM {_indexTableName} 
+                                FROM {_indexTable} 
                                 WHERE saga_id = :id
                             ";
                         command.BindByName = true;
@@ -391,7 +335,7 @@ namespace Rebus.Oracle.Sagas
             {
                 // generate batch insert with SQL for each entry in the index
                 command.CommandText =
-                    $@"INSERT INTO {_indexTableName} (saga_type, key, value, saga_id) VALUES (:saga_type, :key, :value, :saga_id)";
+                    $@"INSERT INTO {_indexTable} (saga_type, key, value, saga_id) VALUES (:saga_type, :key, :value, :saga_id)";
                 command.BindByName = true;
                 command.ArrayBindCount = parameters.Count;
                 command.Parameters.Add(new OracleParameter("saga_type", OracleDbType.NVarchar2, parameters.Select(x => x.SagaType).ToArray(), ParameterDirection.Input));

--- a/Rebus.Oracle/Oracle/Schema/DDL.cs
+++ b/Rebus.Oracle/Oracle/Schema/DDL.cs
@@ -120,5 +120,15 @@ $@"CREATE TABLE {table} (
     CONSTRAINT {table.Name}_pk PRIMARY KEY (id, revision)
 )"
         };
+
+        public static readonly Func<DbName, string[]> dataBus = table => new[] {
+$@"CREATE TABLE {table} (
+    id varchar2(200) CONSTRAINT {table}_pk PRIMARY KEY,
+    meta blob,
+    data blob NOT NULL,
+    creationTime timestamp with time zone NOT NULL,
+    lastReadTime timestamp with time zone
+)"
+        };
     }
 }

--- a/Rebus.Oracle/Oracle/Schema/DDL.cs
+++ b/Rebus.Oracle/Oracle/Schema/DDL.cs
@@ -8,9 +8,9 @@ namespace Rebus.Oracle.Schema
         public static readonly Func<DbName, string[]> transport = table => new[] {
 $@"CREATE TABLE {table}
 (
-    id NUMBER(20) NOT NULL,
-    recipient VARCHAR2(255) NOT NULL,
-    priority NUMBER(20) NOT NULL,
+    id number(20) NOT NULL,
+    recipient varchar2(255) NOT NULL,
+    priority number(20) NOT NULL,
     expiration timestamp with time zone NOT NULL,
     visible timestamp with time zone NOT NULL,
     headers blob NOT NULL,
@@ -27,7 +27,7 @@ $@"CREATE OR REPLACE TRIGGER {table}_on_insert
 BEGIN
     if :new.Id is null then
         :new.id := {table.Name}_seq.nextval;
-    END IF;
+    end if;
 END;",
 
 $@"CREATE INDEX {table.Prefix}idx_receive_{table.Name} ON {table}
@@ -57,6 +57,28 @@ BEGIN
 
     delete from {table.Name} where id = messageId;
 END;"
+        };
+
+        public static readonly Func<DbName, string[]> timeout = table => new[] {
+$@"CREATE TABLE {table} (
+    id number(10) NOT NULL CONSTRAINT {table.Name}_pk PRIMARY KEY,
+    due_time timestamp(7) with time zone NOT NULL,
+    headers CLOB,
+    body BLOB
+)",
+
+$"CREATE SEQUENCE {table}_seq",
+
+$@"CREATE OR REPLACE TRIGGER {table}_on_insert
+    BEFORE INSERT ON {table}
+    FOR EACH ROW
+BEGIN
+    if :new.Id is null then
+        :new.id := {table.Name}_seq.nextval;
+    end if;
+END;",
+
+$"CREATE INDEX {table}_due_idx ON {table} (due_time)"
         };
     }
 }

--- a/Rebus.Oracle/Oracle/Schema/DDL.cs
+++ b/Rebus.Oracle/Oracle/Schema/DDL.cs
@@ -80,5 +80,13 @@ END;",
 
 $"CREATE INDEX {table}_due_idx ON {table} (due_time)"
         };
+
+        public static readonly Func<DbName, string[]> subscription = table => new[] {
+$@"CREATE TABLE {table} (
+    topic varchar(200) NOT NULL,
+    address varchar(200) NOT NULL,
+    PRIMARY KEY (topic, address)
+)"
+        };
     }
 }

--- a/Rebus.Oracle/Oracle/Schema/DDL.cs
+++ b/Rebus.Oracle/Oracle/Schema/DDL.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace Rebus.Oracle.Schema
+{
+    // This file contains DDL scripts to create all objects required by Rebus.Oracle
+    static class DDL
+    {
+        public static readonly Func<DbName, string[]> transport = table => new[] {
+$@"CREATE TABLE {table}
+(
+    id NUMBER(20) NOT NULL,
+    recipient VARCHAR2(255) NOT NULL,
+    priority NUMBER(20) NOT NULL,
+    expiration timestamp with time zone NOT NULL,
+    visible timestamp with time zone NOT NULL,
+    headers blob NOT NULL,
+    body blob NOT NULL,
+
+    CONSTRAINT {table.Name}_pk PRIMARY KEY (recipient, priority, id)
+)",
+
+$"CREATE SEQUENCE {table}_seq",
+
+$@"CREATE OR REPLACE TRIGGER {table}_on_insert
+    BEFORE INSERT ON {table}
+    FOR EACH ROW
+BEGIN
+    if :new.Id is null then
+        :new.id := {table.Name}_seq.nextval;
+    END IF;
+END;",
+
+$@"CREATE INDEX {table.Prefix}idx_receive_{table.Name} ON {table}
+(
+    recipient ASC, 
+    expiration ASC, 
+    visible ASC
+)",
+
+$@"CREATE OR REPLACE PROCEDURE {table.Prefix}rebus_dequeue_{table.Name}(recipientQueue IN varchar, now IN timestamp with time zone, output OUT SYS_REFCURSOR) AS
+    messageId number;
+    readCursor SYS_REFCURSOR; 
+BEGIN
+    open readCursor for 
+    select id
+    from {table.Name}
+    where recipient = recipientQueue
+      and visible < now
+      and expiration > now
+    order by priority ASC, visible ASC, id ASC
+    for update skip locked;
+    
+    fetch readCursor into messageId;
+    close readCursor;
+
+    open output for select * from {table.Name} where id = messageId;
+
+    delete from {table.Name} where id = messageId;
+END;"
+        };
+    }
+}

--- a/Rebus.Oracle/Oracle/Schema/DDL.cs
+++ b/Rebus.Oracle/Oracle/Schema/DDL.cs
@@ -88,5 +88,37 @@ $@"CREATE TABLE {table} (
     PRIMARY KEY (topic, address)
 )"
         };
+
+        public static readonly Func<DbName, string[]> sagaData = table => new[] {
+$@"CREATE TABLE {table} (
+    id raw(16) CONSTRAINT {table.Name}_pk PRIMARY KEY,
+    revision number(10) NOT NULL,
+    data blob NOT NULL
+)"
+        };
+
+        public static readonly Func<DbName, string[]> sagaIndex = table => new[] {
+$@"CREATE TABLE {table} (
+    saga_type nvarchar2(500) NOT NULL,
+    key nvarchar2(500) NOT NULL,
+    value nvarchar2(2000) NOT NULL,
+    saga_id raw(16) NOT NULL,
+
+    CONSTRAINT {table.Name}_pk PRIMARY KEY (key, value, saga_type)
+)",
+
+$"CREATE INDEX {table}_idx ON {table} (saga_id)"
+        };
+
+        public static readonly Func<DbName, string[]> sagaSnapshot = table => new[] {
+$@"CREATE TABLE {table} (
+    id raw(16) NOT NULL,
+    revision number(10) NOT NULL,
+    metadata clob NOT NULL,
+    data blob NOT NULL,
+
+    CONSTRAINT {table.Name}_pk PRIMARY KEY (id, revision)
+)"
+        };
     }
 }

--- a/Rebus.Oracle/Oracle/Schema/DbName.cs
+++ b/Rebus.Oracle/Oracle/Schema/DbName.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace Rebus.Oracle.Schema
+{
+    /// <summary>Represents an object name, either in [Owner.]Name form.</summary>
+    /// <remarks>Escaped names (between double quotes) are not supported.</remarks>
+    public class DbName 
+    {
+        /// <summary>Owner of the object, or null if unqualified.</summary>
+        public string Owner { get; }
+        /// <summary>Name of the object.</summary>
+        public string Name { get; }
+        internal string Prefix { get; }
+
+        private readonly string _full;
+
+        /// <summary></summary>
+        /// <param name="qualifiedName">A full object name, qualified or not.</param>
+        public DbName(string qualifiedName)
+        {
+            if (qualifiedName == null) throw new ArgumentNullException(nameof(qualifiedName));
+            
+            _full = qualifiedName;
+
+            var parts = qualifiedName.Split(new[] { '.' }, 2);
+            if (parts.Length == 2) 
+            {
+                Owner = parts[0];
+                Name = parts[1];
+                Prefix = Owner + '.';
+            }
+            else
+            {
+                Owner = null;
+                Name = qualifiedName;
+                Prefix = "";
+            }            
+        }
+
+        /// <summary></summary>
+        /// <param name="owner">Owner of the object.</param>
+        /// <param name="name">Name of the object.</param>
+        public DbName(string owner, string name)
+        {
+            Owner = owner;
+            Name = name;
+            Prefix = owner != null ? owner + '.' : null;
+            _full = Prefix + Name;
+        }
+
+        /// <inheritdoc />
+        public override string ToString() => _full;
+    }
+}

--- a/Rebus.Oracle/Oracle/Schema/DbSchemaExtensions.cs
+++ b/Rebus.Oracle/Oracle/Schema/DbSchemaExtensions.cs
@@ -15,6 +15,10 @@ namespace Rebus.Oracle.Schema
         public static bool CreateTimeout(this OracleConnection connection, DbName tableName)
             => connection.CreateIfNotExists(tableName, DDL.timeout);
 
+        /// <summary>Create objects supporting Subscriptions.</summary>
+        public static bool CreateSubscription(this OracleConnection connection, DbName tableName)
+            => connection.CreateIfNotExists(tableName, DDL.subscription);
+
         private static bool Exists(this OracleConnection connection, DbName objectName)
         {
             using (var command = connection.CreateCommand())

--- a/Rebus.Oracle/Oracle/Schema/DbSchemaExtensions.cs
+++ b/Rebus.Oracle/Oracle/Schema/DbSchemaExtensions.cs
@@ -11,6 +11,10 @@ namespace Rebus.Oracle.Schema
         public static bool CreateTransport(this OracleConnection connection, DbName tableName) 
             => connection.CreateIfNotExists(tableName, DDL.transport);
 
+        /// <summary>Create objects supporting Timeouts.</summary>
+        public static bool CreateTimeout(this OracleConnection connection, DbName tableName)
+            => connection.CreateIfNotExists(tableName, DDL.timeout);
+
         private static bool Exists(this OracleConnection connection, DbName objectName)
         {
             using (var command = connection.CreateCommand())

--- a/Rebus.Oracle/Oracle/Schema/DbSchemaExtensions.cs
+++ b/Rebus.Oracle/Oracle/Schema/DbSchemaExtensions.cs
@@ -1,0 +1,64 @@
+using System;
+using Oracle.ManagedDataAccess.Client;
+
+namespace Rebus.Oracle.Schema
+{
+    /// <summary>Methods to create the required DB objects supporting Rebus.Oracle.</summary>
+    /// <remarks>These methods are automatically called by Rebus unless you pass automaticallyCreateTables = false during configuration.</remarks>
+    public static class DbSchemaExtensions
+    {
+        /// <summary>Create objects supporting Transport.</summary>
+        public static bool CreateTransport(this OracleConnection connection, DbName tableName) 
+            => connection.CreateIfNotExists(tableName, DDL.transport);
+
+        private static bool Exists(this OracleConnection connection, DbName objectName)
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.BindByName = true;
+
+                if (objectName.Owner == null)
+                {
+                    command.CommandText = "select 1 from user_objects where object_name = upper(:name)";
+                    command.Parameters.Add("name", objectName.Name);
+                }
+                else
+                {
+                    command.CommandText = "select 1 from all_objects where owner = upper(:owner) and object_name = upper(:name)";
+                    command.Parameters.Add("owner", objectName.Owner);
+                    command.Parameters.Add("name", objectName.Name);
+                }
+
+                return command.ExecuteScalar() != null;
+            }
+        }
+
+        private static bool CreateIfNotExists(this OracleConnection connection, DbName tableName, Func<DbName, string[]> ddl)
+        {
+            if (connection == null) throw new ArgumentNullException(nameof(connection));
+
+            if (connection.Exists(tableName)) return false;
+
+            try
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    foreach (var sql in ddl(tableName))
+                    {
+                        command.CommandText = sql;
+                        command.ExecuteNonQuery();
+                    }
+                }
+            }
+            catch 
+            {
+                // We might fail if another process created the same objects concurrently
+                if (connection.Exists(tableName)) return false;
+                // Otherwise propagate the error
+                throw;
+            }
+            
+            return true;
+        }
+    }
+}

--- a/Rebus.Oracle/Oracle/Schema/OracleConnectionExtensions.cs
+++ b/Rebus.Oracle/Oracle/Schema/OracleConnectionExtensions.cs
@@ -5,18 +5,18 @@ namespace Rebus.Oracle.Schema
 {
     /// <summary>Methods to create the required DB objects supporting Rebus.Oracle.</summary>
     /// <remarks>These methods are automatically called by Rebus unless you pass automaticallyCreateTables = false during configuration.</remarks>
-    public static class DbSchemaExtensions
+    public static class OracleConnectionExtensions
     {
         /// <summary>Create objects supporting Transport.</summary>
-        public static bool CreateTransport(this OracleConnection connection, DbName tableName) 
+        public static bool CreateRebusTransport(this OracleConnection connection, DbName tableName) 
             => connection.CreateIfNotExists(tableName, DDL.transport);
 
         /// <summary>Create objects supporting Timeouts.</summary>
-        public static bool CreateTimeout(this OracleConnection connection, DbName tableName)
+        public static bool CreateRebusTimeout(this OracleConnection connection, DbName tableName)
             => connection.CreateIfNotExists(tableName, DDL.timeout);
 
         /// <summary>Create objects supporting Subscriptions.</summary>
-        public static bool CreateSubscription(this OracleConnection connection, DbName tableName)
+        public static bool CreateRebusSubscription(this OracleConnection connection, DbName tableName)
             => connection.CreateIfNotExists(tableName, DDL.subscription);
 
         private static bool Exists(this OracleConnection connection, DbName objectName)

--- a/Rebus.Oracle/Oracle/Schema/OracleConnectionExtensions.cs
+++ b/Rebus.Oracle/Oracle/Schema/OracleConnectionExtensions.cs
@@ -19,6 +19,17 @@ namespace Rebus.Oracle.Schema
         public static bool CreateRebusSubscription(this OracleConnection connection, DbName tableName)
             => connection.CreateIfNotExists(tableName, DDL.subscription);
 
+        /// <summary>Create objects supporting Sagas.</summary>
+        public static bool CreateRebusSaga(this OracleConnection connection, DbName dataTableName, DbName indexTableName)
+        {
+            return connection.CreateIfNotExists(dataTableName, DDL.sagaData) |
+                   connection.CreateIfNotExists(indexTableName, DDL.sagaIndex);
+        }
+
+        /// <summary>Create objects supporting Sagas Snapshots.</summary>
+        public static bool CreateRebusSagaSnapshot(this OracleConnection connection, DbName tableName)
+            => connection.CreateIfNotExists(tableName, DDL.sagaSnapshot);
+
         private static bool Exists(this OracleConnection connection, DbName objectName)
         {
             using (var command = connection.CreateCommand())

--- a/Rebus.Oracle/Oracle/Schema/OracleConnectionExtensions.cs
+++ b/Rebus.Oracle/Oracle/Schema/OracleConnectionExtensions.cs
@@ -30,6 +30,10 @@ namespace Rebus.Oracle.Schema
         public static bool CreateRebusSagaSnapshot(this OracleConnection connection, DbName tableName)
             => connection.CreateIfNotExists(tableName, DDL.sagaSnapshot);
 
+        /// <summary>Create objects supporting DataBus.</summary>
+        public static bool CreateRebusDataBus(this OracleConnection connection, DbName tableName)
+            => connection.CreateIfNotExists(tableName, DDL.dataBus);
+
         private static bool Exists(this OracleConnection connection, DbName objectName)
         {
             using (var command = connection.CreateCommand())

--- a/Rebus.Oracle/Oracle/Subscriptions/OracleSubscriptionStorage.cs
+++ b/Rebus.Oracle/Oracle/Subscriptions/OracleSubscriptionStorage.cs
@@ -41,7 +41,7 @@ namespace Rebus.Oracle.Subscriptions
         {
             using (var connection = _connectionHelper.GetConnection())
             {
-                if (connection.Connection.CreateSubscription(_table))
+                if (connection.Connection.CreateRebusSubscription(_table))
                     _log.Info("Table {tableName} does not exist - it will be created now", _table);
             }
         }

--- a/Rebus.Oracle/Oracle/Subscriptions/OracleSubscriptionStorage.cs
+++ b/Rebus.Oracle/Oracle/Subscriptions/OracleSubscriptionStorage.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using System.Threading.Tasks;
 using Oracle.ManagedDataAccess.Client;
 using Rebus.Logging;
+using Rebus.Oracle.Schema;
 using Rebus.Subscriptions;
 
 namespace Rebus.Oracle.Subscriptions
@@ -17,7 +17,7 @@ namespace Rebus.Oracle.Subscriptions
         const int UniqueKeyViolation = 1;
 
         readonly OracleConnectionHelper _connectionHelper;
-        readonly string _tableName;
+        readonly DbName _table;
         readonly ILog _log;
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Rebus.Oracle.Subscriptions
         {
             if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
             _connectionHelper = connectionHelper ?? throw new ArgumentNullException(nameof(connectionHelper));
-            _tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
+            _table = new DbName(tableName) ?? throw new ArgumentNullException(nameof(tableName));
             IsCentralized = isCentralized;
             _log = rebusLoggerFactory.GetLogger<OracleSubscriptionStorage>();
         }
@@ -41,25 +41,8 @@ namespace Rebus.Oracle.Subscriptions
         {
             using (var connection = _connectionHelper.GetConnection())
             {
-                var tableNames = connection.GetTableNames();
-
-                if (tableNames.Any(tableName => _tableName.Equals(tableName, StringComparison.InvariantCultureIgnoreCase))) return;
-
-                _log.Info("Table {tableName} does not exist - it will be created now", _tableName);
-
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText =
-                        $@"
-CREATE TABLE {_tableName} (
-    topic VARCHAR(200) NOT NULL,
-    address VARCHAR(200) NOT NULL,
-    PRIMARY KEY (topic,address)
-)";
-                    command.ExecuteNonQuery();
-                }
-
-                connection.Complete();
+                if (connection.Connection.CreateSubscription(_table))
+                    _log.Info("Table {tableName} does not exist - it will be created now", _table);
             }
         }
 
@@ -71,7 +54,7 @@ CREATE TABLE {_tableName} (
             using (var connection = _connectionHelper.GetConnection())
             using (var command = connection.CreateCommand())
             {
-                command.CommandText = $@"select address from {_tableName} where topic = :topic";
+                command.CommandText = $@"select address from {_table} where topic = :topic";
                 command.BindByName = true;
 
                 command.Parameters.Add(new OracleParameter("topic", OracleDbType.Varchar2, topic, ParameterDirection.Input));
@@ -99,7 +82,7 @@ CREATE TABLE {_tableName} (
             using (var command = connection.CreateCommand())
             {
                 command.CommandText =
-                    $@"insert into {_tableName} (topic, address) values (:topic, :address)";
+                    $@"insert into {_table} (topic, address) values (:topic, :address)";
 
                 command.BindByName = true;
                 command.Parameters.Add(new OracleParameter("topic", OracleDbType.Varchar2, topic, ParameterDirection.Input));
@@ -128,7 +111,7 @@ CREATE TABLE {_tableName} (
             using (var command = connection.CreateCommand())
             {
                 command.CommandText =
-                    $@"delete from {_tableName} where topic = :topic and address = :address";
+                    $@"delete from {_table} where topic = :topic and address = :address";
 
                 command.BindByName = true;
                 command.Parameters.Add(new OracleParameter("topic", OracleDbType.Varchar2, topic, ParameterDirection.Input));

--- a/Rebus.Oracle/Oracle/Timeouts/OracleTimeoutManager.cs
+++ b/Rebus.Oracle/Oracle/Timeouts/OracleTimeoutManager.cs
@@ -128,7 +128,7 @@ namespace Rebus.Oracle.Timeouts
         {
             using (var connection = _connectionHelper.GetConnection())
             {
-                if (connection.Connection.CreateTimeout(_table))
+                if (connection.Connection.CreateRebusTimeout(_table))
                     _log.Info("Table {tableName} does not exist - it will be created now", _table);
             }
         }

--- a/Rebus.Oracle/Oracle/Timeouts/OracleTimeoutManager.cs
+++ b/Rebus.Oracle/Oracle/Timeouts/OracleTimeoutManager.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Oracle.ManagedDataAccess.Client;
 using Rebus.Logging;
+using Rebus.Oracle.Schema;
 using Rebus.Serialization;
 using Rebus.Time;
 using Rebus.Timeouts;
@@ -24,7 +23,7 @@ namespace Rebus.Oracle.Timeouts
     {
         readonly DictionarySerializer _dictionarySerializer = new DictionarySerializer();
         readonly OracleConnectionHelper _connectionHelper;
-        readonly string _tableName;
+        readonly DbName _table;
         readonly ILog _log;
         readonly IRebusTime _rebusTime;
 
@@ -35,7 +34,7 @@ namespace Rebus.Oracle.Timeouts
         {
             if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
             _connectionHelper = connectionHelper ?? throw new ArgumentNullException(nameof(connectionHelper));
-            _tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
+            _table = new DbName(tableName) ?? throw new ArgumentNullException(nameof(tableName));
             _log = rebusLoggerFactory.GetLogger<OracleTimeoutManager>();
             _rebusTime = rebusTime ?? throw new ArgumentNullException(nameof(rebusTime));
         }
@@ -50,7 +49,7 @@ namespace Rebus.Oracle.Timeouts
                 using (var command = connection.CreateCommand())
                 {
                     command.CommandText =
-                        $@"INSERT INTO {_tableName} (due_time, headers, body) VALUES (:due_time, :headers, :body)"; 
+                        $@"INSERT INTO {_table} (due_time, headers, body) VALUES (:due_time, :headers, :body)"; 
                     command.BindByName = true;
                     command.Parameters.Add(new OracleParameter("due_time", OracleDbType.TimeStampTZ, approximateDueTime.ToOracleTimeStamp(), ParameterDirection.Input));
                     command.Parameters.Add(new OracleParameter("headers", OracleDbType.Clob, _dictionarySerializer.SerializeToString(headers), ParameterDirection.Input));
@@ -74,21 +73,14 @@ namespace Rebus.Oracle.Timeouts
             {
                 using (var command = connection.CreateCommand())
                 {
-                    command.CommandText =
-                        $@"
-                        SELECT
-                            id,
-                            headers, 
-                            body 
-
-                        FROM {_tableName} 
-
+                    command.CommandText =$@"
+                        SELECT id, headers, body 
+                        FROM {_table} 
                         WHERE due_time <= :current_time 
-
                         ORDER BY due_time
                         FOR UPDATE";
                     command.BindByName = true;
-                    command.Parameters.Add(new OracleParameter("current_time", OracleDbType.TimeStampTZ, _rebusTime.Now.ToOracleTimeStamp(), ParameterDirection.Input));
+                    command.Parameters.Add(new OracleParameter("current_time", _rebusTime.Now.ToOracleTimeStamp()));
 
                     using (var reader = command.ExecuteReader())
                     {
@@ -105,7 +97,7 @@ namespace Rebus.Oracle.Timeouts
                                 using (var deleteCommand = connection.CreateCommand())
                                 {
                                     deleteCommand.BindByName = true;
-                                    deleteCommand.CommandText = $@"DELETE FROM {_tableName} WHERE id = :id";
+                                    deleteCommand.CommandText = $@"DELETE FROM {_table} WHERE id = :id";
                                     deleteCommand.Parameters.Add(new OracleParameter("id", OracleDbType.Int64, id, ParameterDirection.Input));
                                     deleteCommand.ExecuteNonQuery();
                                     return Task.CompletedTask;
@@ -136,59 +128,8 @@ namespace Rebus.Oracle.Timeouts
         {
             using (var connection = _connectionHelper.GetConnection())
             {
-                var tableNames = connection.GetTableNames();
-
-                if (tableNames.Contains(_tableName, StringComparer.OrdinalIgnoreCase))
-                {
-                    return;
-                }
-
-                _log.Info("Table {tableName} does not exist - it will be created now", _tableName);
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText =
-                        $@"
-                        CREATE TABLE {_tableName} (
-                            id NUMBER(10) NOT NULL,
-                            due_time TIMESTAMP(7) WITH TIME ZONE NOT NULL,
-                            headers CLOB,
-                            body BLOB,
-                            CONSTRAINT {_tableName}_pk PRIMARY KEY(id)
-                         )";
-
-                    command.ExecuteNonQuery();
-                }
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText =
-                        $@"CREATE SEQUENCE {_tableName}_SEQ";
-                    command.ExecuteNonQuery();
-                }
-
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText =
-                        $@"
-                        CREATE OR REPLACE TRIGGER {_tableName}_on_insert
-                             BEFORE INSERT ON {_tableName}
-                             FOR EACH ROW
-                        BEGIN
-                            if :new.Id is null then
-                              :new.id := {_tableName}_seq.nextval;
-                            END IF;
-                        END;
-                        ";
-                    command.ExecuteNonQuery();
-                }
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText = $@"
-                        CREATE INDEX {_tableName}_due_idx ON {_tableName} (due_time)";
-
-                    command.ExecuteNonQuery();
-                }
-
-                connection.Complete();
+                if (connection.Connection.CreateTimeout(_table))
+                    _log.Info("Table {tableName} does not exist - it will be created now", _table);
             }
         }
     }

--- a/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
+++ b/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
@@ -241,7 +241,7 @@ namespace Rebus.Oracle.Transport
             {
                 using (var connection = _connectionHelper.GetConnection())
                 {
-                    if (connection.Connection.CreateTransport(_table))
+                    if (connection.Connection.CreateRebusTransport(_table))
                         _log.Info("Table {tableName} does not exist - it will be created now", _table);
                     else
                         _log.Info("Database already contains a table named {tableName} - will not create anything", _table);

--- a/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
+++ b/Rebus.Oracle/Oracle/Transport/OracleTransport.cs
@@ -307,13 +307,15 @@ begin
     WHERE recipient = recipientQueue
             and visible < current_timestamp(6)
             and expiration > current_timestamp(6)          
-    ORDER BY priority ASC, id ASC
+    ORDER BY priority ASC, visible ASC, id ASC
     for update skip locked;
     
     fetch readCursor into messageId;
-    close readCursor;      
-  open output for select * from {_tableName} where id = messageId;
-  delete from {_tableName} where id = messageId;
+    close readCursor;
+
+    open output for select * from {_tableName} where id = messageId;
+
+    delete from {_tableName} where id = messageId;
 END;
 ");
 

--- a/Rebus.Oracle/Rebus.Oracle.csproj
+++ b/Rebus.Oracle/Rebus.Oracle.csproj
@@ -41,8 +41,8 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.12.0-beta3" />
-    <PackageReference Include="Rebus" Version="4.2.1" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.18.3" />
+    <PackageReference Include="Rebus" Version="6.0.0-b11" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />


### PR DESCRIPTION
This is done on top of #18 

I have refactored all schema creation code into a new class. 
It helps keeping the other classes more focused and reduces duplication a bit.

👉  I made it public, so that it can be used to create the schema at another time / with another user.

👉  I also moved all DDL statements in a single file with nothing else, so that they are easy to pick up if someone wants to create the schema through another mean (e.g. running scripts manually with an admin user). Security best practices ;)

❌ The scripts (and code for that matter) are full of inconsistencies (e.g. `varchar` vs `nvarchar2`, naming, ...) but this PR does not change them.

👉 I changed the way existing tables are detected to make it a lot more efficient in large schemas.

Above changes fix #10.

👉  I added a flag to not create automatically the transport schema. Somehow, it was the only part that did not have such a flag (did I say consistency?).

👉 I added support for 2-part names such as `Rebus.Saga`. 

This is useful if you want to re-use the same Oracle connections as your application code but still keep each app and rebus in their own schema (instead of opening 2 connections with different users).
But the real motivation is in preparation of #13. When you enlist with the app's own logic, you won't have an option to open different connections anymore.

📢 `Rebus.Saga` works but take notice:
- `Rebus` DB user won't be created automatically (that's nasty in Oracle, it's more than a SQL Server schema). It has to exist ahead of time.
- Of course the current user needs appropriate grants to create DB objects in the respective schema (if you let Rebus create them); plus grants to read/write inside them. This library does not grant rights.

❌ Quoted names like `Rebus."Saga Snapshot"` did not work before, they still don't.

> ⚠️ Tests have not been run yet.