### PR TITLE
Port some recent changes to Rebus.Oracle.Devart

### DIFF
--- a/Rebus.Oracle.Devart/Config/OracleConfigurationExtensions.cs
+++ b/Rebus.Oracle.Devart/Config/OracleConfigurationExtensions.cs
@@ -8,6 +8,7 @@ using Rebus.Oracle.Subscriptions;
 using Rebus.Oracle.Timeouts;
 using Rebus.Sagas;
 using Rebus.Subscriptions;
+using Rebus.Time;
 using Rebus.Timeouts;
 
 namespace Rebus.Config
@@ -68,7 +69,8 @@ namespace Rebus.Config
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var subscriptionStorage = new OracleTimeoutManager(new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction), tableName, rebusLoggerFactory);
+                var rebusTime = c.Get<IRebusTime>();
+                var subscriptionStorage = new OracleTimeoutManager(new OracleConnectionHelper(connectionString, additionalConnectionSetup, enlistInAmbientTransaction), tableName, rebusLoggerFactory, rebusTime);
 
                 if (automaticallyCreateTables)
                 {

--- a/Rebus.Oracle.Devart/Config/OracleTransportConfigurationExtensions.cs
+++ b/Rebus.Oracle.Devart/Config/OracleTransportConfigurationExtensions.cs
@@ -5,6 +5,7 @@ using Rebus.Oracle.Transport;
 using Rebus.Pipeline;
 using Rebus.Pipeline.Receive;
 using Rebus.Threading;
+using Rebus.Time;
 using Rebus.Timeouts;
 using Rebus.Transport;
 
@@ -43,8 +44,9 @@ namespace Rebus.Config
             {
                 var rebusLoggerFactory = context.Get<IRebusLoggerFactory>();
                 var asyncTaskFactory = context.Get<IAsyncTaskFactory>();
+                var rebusTime = context.Get<IRebusTime>();
                 var connectionProvider = connectionProviderFactory(rebusLoggerFactory);
-                var transport = new OracleTransport(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory);
+                var transport = new OracleTransport(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory, rebusTime);
                 transport.EnsureTableIsCreated();
                 return transport;
             });

--- a/Rebus.Oracle.Devart/Oracle/Sagas/OracleSagaSnapshotStorage.cs
+++ b/Rebus.Oracle.Devart/Oracle/Sagas/OracleSagaSnapshotStorage.cs
@@ -31,7 +31,7 @@ namespace Rebus.Oracle.Sagas
         /// <summary>
         /// Saves the <paramref name="sagaData"/> snapshot and the accompanying <paramref name="sagaAuditMetadata"/>
         /// </summary>
-        public async Task Save(ISagaData sagaData, Dictionary<string, string> sagaAuditMetadata)
+        public Task Save(ISagaData sagaData, Dictionary<string, string> sagaAuditMetadata)
         {
             using (var connection = _connectionHelper.GetConnection())
             {
@@ -49,10 +49,11 @@ namespace Rebus.Oracle.Sagas
                     command.Parameters.Add("metadata", OracleDbType.Clob).Value =
                     _dictionarySerializer.SerializeToString(sagaAuditMetadata);
 
-                    await command.ExecuteNonQueryAsync();
+                    command.ExecuteNonQuery();
                 }
                 
                 connection.Complete();
+                return Task.CompletedTask;
             }
         }
 

--- a/Rebus.Oracle.Devart/Oracle/Sagas/OracleSqlSagaStorage.cs
+++ b/Rebus.Oracle.Devart/Oracle/Sagas/OracleSqlSagaStorage.cs
@@ -20,7 +20,7 @@ namespace Rebus.Oracle.Sagas
     /// </summary>
     public class OracleSqlSagaStorage : ISagaStorage
     {
-        static readonly string IdPropertyName = Reflect.Path<ISagaData>(d => d.Id);
+        const string IdPropertyName = nameof(ISagaData.Id);
 
         readonly ObjectSerializer _objectSerializer = new ObjectSerializer();
         readonly OracleConnectionHelper _connectionHelper;
@@ -43,7 +43,7 @@ namespace Rebus.Oracle.Sagas
 
         /// <summary>
         /// Checks to see if the configured saga data and saga index table exists. If they both exist, we'll continue, if
-        /// neigther of them exists, we'll try to create them. If one of them exists, we'll throw an error.
+        /// neither of them exists, we'll try to create them. If one of them exists, we'll throw an error.
         /// </summary>
         public void EnsureTablesAreCreated()
         {

--- a/Rebus.Oracle.Devart/Oracle/Sagas/OracleSqlSagaStorage.cs
+++ b/Rebus.Oracle.Devart/Oracle/Sagas/OracleSqlSagaStorage.cs
@@ -115,7 +115,7 @@ namespace Rebus.Oracle.Sagas
         /// Finds an already-existing instance of the given saga data type that has a property with the given <paramref name="propertyName" />
         /// whose value matches <paramref name="propertyValue" />. Returns null if no such instance could be found
         /// </summary>
-        public async Task<ISagaData> Find(Type sagaDataType, string propertyName, object propertyValue)
+        public Task<ISagaData> Find(Type sagaDataType, string propertyName, object propertyValue)
         {
             using (var connection = _connectionHelper.GetConnection())
             {
@@ -144,9 +144,9 @@ namespace Rebus.Oracle.Sagas
                         command.Parameters.Add(new OracleParameter("value", OracleDbType.NVarChar, (propertyValue ?? "").ToString(), ParameterDirection.Input));
                     }
 
-                    var data = (byte[]) await command.ExecuteScalarAsync();
+                    var data = (byte[]) command.ExecuteScalar();
 
-                    if (data == null) return null;
+                    if (data == null) return Task.FromResult<ISagaData>(null);
 
                     try
                     {
@@ -154,10 +154,10 @@ namespace Rebus.Oracle.Sagas
 
                         if (!sagaDataType.IsInstanceOfType(sagaData))
                         {
-                            return null;
+                            return Task.FromResult<ISagaData>(null);
                         }
 
-                        return sagaData;
+                        return Task.FromResult(sagaData);
                     }
                     catch (Exception exception)
                     {
@@ -183,7 +183,7 @@ namespace Rebus.Oracle.Sagas
         /// Inserts the given saga data as a new instance. Throws a <see cref="T:Rebus.Exceptions.ConcurrencyException" /> if another saga data instance
         /// already exists with a correlation property that shares a value with this saga data.
         /// </summary>
-        public async Task Insert(ISagaData sagaData, IEnumerable<ISagaCorrelationProperty> correlationProperties)
+        public Task Insert(ISagaData sagaData, IEnumerable<ISagaCorrelationProperty> correlationProperties)
         {
             if (sagaData.Id == Guid.Empty)
             {
@@ -214,7 +214,7 @@ namespace Rebus.Oracle.Sagas
 
                     try
                     {
-                        await command.ExecuteNonQueryAsync();
+                        command.ExecuteNonQuery();
                     }
                     catch (OracleException exception)
                     {
@@ -227,10 +227,11 @@ namespace Rebus.Oracle.Sagas
 
                 if (propertiesToIndex.Any())
                 {
-                    await CreateIndex(sagaData, connection, propertiesToIndex);
+                    CreateIndex(sagaData, connection, propertiesToIndex);
                 }
 
                 connection.Complete();
+                return Task.CompletedTask;
             }
         }
 
@@ -239,7 +240,7 @@ namespace Rebus.Oracle.Sagas
         /// saga data instance exists with a correlation property that shares a value with this saga data, or if the saga data
         /// instance no longer exists.
         /// </summary>
-        public async Task Update(ISagaData sagaData, IEnumerable<ISagaCorrelationProperty> correlationProperties)
+        public Task Update(ISagaData sagaData, IEnumerable<ISagaCorrelationProperty> correlationProperties)
         {
             using (var connection = _connectionHelper.GetConnection())
             {
@@ -254,7 +255,7 @@ namespace Rebus.Oracle.Sagas
                 {
                     command.CommandText = $@"DELETE FROM {_indexTableName} WHERE saga_id = :id";
                     command.Parameters.Add("id", OracleDbType.Raw).Value = sagaData.Id;
-                    await command.ExecuteNonQueryAsync();
+                    command.ExecuteNonQuery();
                 }
 
                 // next, update or insert the saga
@@ -272,7 +273,7 @@ namespace Rebus.Oracle.Sagas
                             WHERE id = :id AND revision = :current_revision
                         ";
 
-                    var rows = await command.ExecuteNonQueryAsync();
+                    var rows = command.ExecuteNonQuery();
 
                     if (rows == 0)
                     {
@@ -285,61 +286,72 @@ namespace Rebus.Oracle.Sagas
 
                 if (propertiesToIndex.Any())
                 {
-                    await CreateIndex(sagaData, connection, propertiesToIndex);
+                    CreateIndex(sagaData, connection, propertiesToIndex);
                 }
 
                 connection.Complete();
+                return Task.CompletedTask;
             }
         }
 
         /// <summary>
         /// Deletes the saga data instance, throwing a <see cref="T:Rebus.Exceptions.ConcurrencyException" /> if the instance no longer exists
         /// </summary>
-        public async Task Delete(ISagaData sagaData)
+        public Task Delete(ISagaData sagaData)
         {
-            using (var connection = _connectionHelper.GetConnection())
+            try
             {
-                using (var command = connection.CreateCommand())
+                using (var connection = _connectionHelper.GetConnection())
                 {
-                    command.CommandText =
-                        $@"
-                        DELETE 
-                            FROM {_dataTableName} 
-                            WHERE id = :id AND revision = :current_revision
-                        ";
-
-                    command.Parameters.Add("id", OracleDbType.Raw).Value = sagaData.Id;
-                    command.Parameters.Add("current_revision", OracleDbType.Int64).Value = sagaData.Revision;
-
-                    var rows = await command.ExecuteNonQueryAsync();
-
-                    if (rows == 0)
+                    using (var command = connection.CreateCommand())
                     {
-                        throw new ConcurrencyException(
-                            $"Delete of saga with ID {sagaData.Id} did not succeed because someone else beat us to it");
+                        command.CommandText =
+                            $@"
+                            DELETE 
+                                FROM {_dataTableName} 
+                                WHERE id = :id AND revision = :current_revision
+                            ";
+
+                        command.Parameters.Add("id", OracleDbType.Raw).Value = sagaData.Id;
+                        command.Parameters.Add("current_revision", OracleDbType.Int64).Value = sagaData.Revision;
+
+                        var rows = command.ExecuteNonQuery();
+
+                        if (rows == 0)
+                        {
+                            throw new ConcurrencyException(
+                                $"Delete of saga with ID {sagaData.Id} did not succeed because someone else beat us to it");
+                        }
                     }
+
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText =
+                            $@"
+                            DELETE 
+                                FROM {_indexTableName} 
+                                WHERE saga_id = :id
+                            ";
+                        command.Parameters.Add("id", OracleDbType.Raw).Value = sagaData.Id;
+
+                        command.ExecuteNonQuery();
+                    }
+
+                    connection.Complete();
                 }
 
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText =
-                        $@"
-                        DELETE 
-                            FROM {_indexTableName} 
-                            WHERE saga_id = :id
-                        ";
-                    command.Parameters.Add("id", OracleDbType.Raw).Value = sagaData.Id;
+                sagaData.Revision++;
 
-                    await command.ExecuteNonQueryAsync();
-                }
-
-                connection.Complete();
+                return Task.CompletedTask;
             }
-
-            sagaData.Revision++;
+            catch (Exception ex)
+            {
+                // Wrap in AggregateException to comply with Rebus contract. Tests do look for this specific exception type.
+                throw new AggregateException(ex);
+            }
         }
 
-        async Task CreateIndex(ISagaData sagaData, OracleDbConnection connection,
+        void CreateIndex(ISagaData sagaData, OracleDbConnection connection,
             IEnumerable<KeyValuePair<string, string>> propertiesToIndex)
         {
             var sagaTypeName = GetSagaTypeName(sagaData.GetType());

--- a/Rebus.Oracle.Devart/Oracle/Subscriptions/OracleSubscriptionStorage.cs
+++ b/Rebus.Oracle.Devart/Oracle/Subscriptions/OracleSubscriptionStorage.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using Devart.Data.Oracle;
+using Rebus.Exceptions;
 using Rebus.Logging;
 using Rebus.Subscriptions;
 
@@ -137,7 +138,7 @@ CREATE TABLE {_tableName} (
                 }
                 catch (OracleException exception)
                 {
-                    Console.WriteLine(exception);
+                    throw new RebusApplicationException(exception, "Failed to delete subscription from storage");
                 }
 
                 connection.Complete();

--- a/Rebus.Oracle.Devart/Oracle/Subscriptions/OracleSubscriptionStorage.cs
+++ b/Rebus.Oracle.Devart/Oracle/Subscriptions/OracleSubscriptionStorage.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Devart.Data.Oracle;
-using Rebus.Extensions;
 using Rebus.Logging;
 using Rebus.Subscriptions;
 
@@ -68,7 +66,7 @@ CREATE TABLE {_tableName} (
         /// <summary>
         /// Gets all destination addresses for the given topic
         /// </summary>
-        public async Task<string[]> GetSubscriberAddresses(string topic)
+        public Task<string[]> GetSubscriberAddresses(string topic)
         {
             using (var connection = _connectionHelper.GetConnection())
             using (var command = connection.CreateCommand())
@@ -79,7 +77,7 @@ CREATE TABLE {_tableName} (
 
                 var endpoints = new List<string>();
 
-                using (var reader = await command.ExecuteReaderAsync())
+                using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())
                     {
@@ -87,14 +85,14 @@ CREATE TABLE {_tableName} (
                     }
                 }
 
-                return endpoints.ToArray();
+                return Task.FromResult(endpoints.ToArray());
             }
         }
 
         /// <summary>
         /// Registers the given <paramref name="subscriberAddress" /> as a subscriber of the given topic
         /// </summary>
-        public async Task RegisterSubscriber(string topic, string subscriberAddress)
+        public Task RegisterSubscriber(string topic, string subscriberAddress)
         {
             using (var connection = _connectionHelper.GetConnection())
             using (var command = connection.CreateCommand())
@@ -107,7 +105,7 @@ CREATE TABLE {_tableName} (
 
                 try
                 {
-                    await command.ExecuteNonQueryAsync();
+                    command.ExecuteNonQuery();
                 }
                 catch (OracleException exception) when (exception.Code == UniqueKeyViolation)
                 {
@@ -115,13 +113,14 @@ CREATE TABLE {_tableName} (
                 }
 
                 connection.Complete();
+                return Task.CompletedTask;
             }
         }
 
         /// <summary>
         /// Unregisters the given <paramref name="subscriberAddress" /> as a subscriber of the given topic
         /// </summary>
-        public async Task UnregisterSubscriber(string topic, string subscriberAddress)
+        public Task UnregisterSubscriber(string topic, string subscriberAddress)
         {
             using (var connection = _connectionHelper.GetConnection())
             using (var command = connection.CreateCommand())
@@ -134,7 +133,7 @@ CREATE TABLE {_tableName} (
 
                 try
                 {
-                    await command.ExecuteNonQueryAsync();
+                    command.ExecuteNonQuery();
                 }
                 catch (OracleException exception)
                 {
@@ -142,6 +141,7 @@ CREATE TABLE {_tableName} (
                 }
 
                 connection.Complete();
+                return Task.CompletedTask;
             }
         }
 

--- a/Rebus.Oracle.Devart/Oracle/Timeouts/OracleTimeoutManager.cs
+++ b/Rebus.Oracle.Devart/Oracle/Timeouts/OracleTimeoutManager.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Devart.Data.Oracle;
 using Rebus.Logging;
@@ -43,7 +42,7 @@ namespace Rebus.Oracle.Timeouts
         /// <summary>
         /// Stores the message with the given headers and body data, delaying it until the specified <paramref name="approximateDueTime" />
         /// </summary>
-        public async Task Defer(DateTimeOffset approximateDueTime, Dictionary<string, string> headers, byte[] body)
+        public Task Defer(DateTimeOffset approximateDueTime, Dictionary<string, string> headers, byte[] body)
         {
             using (var connection = _connectionHelper.GetConnection())
             {
@@ -54,17 +53,18 @@ namespace Rebus.Oracle.Timeouts
                     command.Parameters.Add(new OracleParameter("due_time", OracleDbType.TimeStampTZ, approximateDueTime.ToUniversalTime().DateTime, ParameterDirection.Input));
                     command.Parameters.Add(new OracleParameter("headers", OracleDbType.Clob, _dictionarySerializer.SerializeToString(headers), ParameterDirection.Input));
                     command.Parameters.Add(new OracleParameter("body", OracleDbType.Blob, body, ParameterDirection.Input));
-                    await command.ExecuteNonQueryAsync();
+                    command.ExecuteNonQuery();
                 }
 
                 connection.Complete();
+                return Task.CompletedTask;
             }
         }
 
         /// <summary>
         /// Gets due messages as of now, given the approximate due time that they were stored with when <see cref="M:Rebus.Timeouts.ITimeoutManager.Defer(System.DateTimeOffset,System.Collections.Generic.Dictionary{System.String,System.String},System.Byte[])" /> was called
         /// </summary>
-        public async Task<DueMessagesResult> GetDueMessages()
+        public Task<DueMessagesResult> GetDueMessages()
         {
             var connection = _connectionHelper.GetConnection();
 
@@ -87,7 +87,7 @@ namespace Rebus.Oracle.Timeouts
                         FOR UPDATE";
                     command.Parameters.Add(new OracleParameter("current_time", OracleDbType.TimeStampTZ, _rebusTime.Now.ToUniversalTime().DateTime, ParameterDirection.Input));
 
-                    using (var reader = await command.ExecuteReaderAsync())
+                    using (var reader = command.ExecuteReader())
                     {
                         var dueMessages = new List<DueMessage>();
 
@@ -97,22 +97,24 @@ namespace Rebus.Oracle.Timeouts
                             var headers = _dictionarySerializer.DeserializeFromString((string) reader["headers"]);
                             var body = (byte[]) reader["body"];
 
-                            dueMessages.Add(new DueMessage(headers, body, async () =>
+                            dueMessages.Add(new DueMessage(headers, body, () =>
                             {
                                 using (var deleteCommand = connection.CreateCommand())
                                 {
                                     deleteCommand.CommandText = $@"DELETE FROM {_tableName} WHERE id = :id";
                                     deleteCommand.Parameters.Add(new OracleParameter("id", OracleDbType.Int64, id, ParameterDirection.Input));
-                                    await deleteCommand.ExecuteNonQueryAsync();
+                                    deleteCommand.ExecuteNonQuery();
+                                    return Task.CompletedTask;
                                 }
                             }));
                         }
 
-                        return new DueMessagesResult(dueMessages, async () =>
+                        return Task.FromResult(new DueMessagesResult(dueMessages, () =>
                         {
                             connection.Complete();
                             connection.Dispose();
-                        });
+                            return Task.CompletedTask;
+                        }));
                     }
                 }
             }

--- a/Rebus.Oracle.Devart/Oracle/Timeouts/OracleTimeoutManager.cs
+++ b/Rebus.Oracle.Devart/Oracle/Timeouts/OracleTimeoutManager.cs
@@ -26,16 +26,18 @@ namespace Rebus.Oracle.Timeouts
         readonly OracleConnectionHelper _connectionHelper;
         readonly string _tableName;
         readonly ILog _log;
+        readonly IRebusTime _rebusTime;
 
         /// <summary>
         /// Constructs the timeout manager
         /// </summary>
-        public OracleTimeoutManager(OracleConnectionHelper connectionHelper, string tableName, IRebusLoggerFactory rebusLoggerFactory)
+        public OracleTimeoutManager(OracleConnectionHelper connectionHelper, string tableName, IRebusLoggerFactory rebusLoggerFactory, IRebusTime rebusTime)
         {
             if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
             _connectionHelper = connectionHelper ?? throw new ArgumentNullException(nameof(connectionHelper));
             _tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
             _log = rebusLoggerFactory.GetLogger<OracleTimeoutManager>();
+            _rebusTime = rebusTime ?? throw new ArgumentNullException(nameof(rebusTime));
         }
 
         /// <summary>
@@ -83,7 +85,7 @@ namespace Rebus.Oracle.Timeouts
 
                         ORDER BY due_time
                         FOR UPDATE";
-                    command.Parameters.Add(new OracleParameter("current_time", OracleDbType.TimeStampTZ, RebusTime.Now.ToUniversalTime().DateTime, ParameterDirection.Input));
+                    command.Parameters.Add(new OracleParameter("current_time", OracleDbType.TimeStampTZ, _rebusTime.Now.ToUniversalTime().DateTime, ParameterDirection.Input));
 
                     using (var reader = await command.ExecuteReaderAsync())
                     {

--- a/Rebus.Oracle.Devart/Oracle/Transport/DisabledTimeoutManager.cs
+++ b/Rebus.Oracle.Devart/Oracle/Transport/DisabledTimeoutManager.cs
@@ -18,7 +18,7 @@ namespace Rebus.Oracle.Transport
             var message =
                 $"Received message with ID {messageIdToPrint} which is supposed to be deferred until {approximateDueTime} -" +
                 " this is a problem, because the internal handling of deferred messages is" +
-                " disabled when using SQL Server as the transport layer in, which" +
+                " disabled when using Oracle as the transport layer in, which" +
                 " case the native support for a specific visibility time is used...";
 
             throw new InvalidOperationException(message);

--- a/Rebus.Oracle.Devart/Oracle/Transport/OracleTransport.cs
+++ b/Rebus.Oracle.Devart/Oracle/Transport/OracleTransport.cs
@@ -29,6 +29,7 @@ namespace Rebus.Oracle.Transport
 
         readonly OracleConnectionHelper _connectionHelper;
         readonly string _tableName;
+        readonly string _inputQueueName;
         readonly AsyncBottleneck _receiveBottleneck = new AsyncBottleneck(20);
         readonly IAsyncTask _expiredMessagesCleanupTask;
         readonly ILog _log;

--- a/Rebus.Oracle.Devart/Oracle/Transport/OracleTransport.cs
+++ b/Rebus.Oracle.Devart/Oracle/Transport/OracleTransport.cs
@@ -34,6 +34,7 @@ namespace Rebus.Oracle.Transport
         readonly AsyncBottleneck _receiveBottleneck = new AsyncBottleneck(20);
         readonly IAsyncTask _expiredMessagesCleanupTask;
         readonly ILog _log;
+        readonly IRebusTime _rebusTime;
 
         bool _disposed;
 
@@ -57,12 +58,14 @@ namespace Rebus.Oracle.Transport
         /// <param name="inputQueueName"></param>
         /// <param name="rebusLoggerFactory"></param>
         /// <param name="asyncTaskFactory"></param>
-        public OracleTransport(OracleConnectionHelper connectionHelper, string tableName, string inputQueueName, IRebusLoggerFactory rebusLoggerFactory, IAsyncTaskFactory asyncTaskFactory)
+        /// <param name="rebusTime"></param>
+        public OracleTransport(OracleConnectionHelper connectionHelper, string tableName, string inputQueueName, IRebusLoggerFactory rebusLoggerFactory, IAsyncTaskFactory asyncTaskFactory, IRebusTime rebusTime)
         {
             if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
             if (asyncTaskFactory == null) throw new ArgumentNullException(nameof(asyncTaskFactory));
 
             _log = rebusLoggerFactory.GetLogger<OracleTransport>();
+            _rebusTime = rebusTime ?? throw new ArgumentNullException(nameof(rebusTime));
             _connectionHelper = connectionHelper ?? throw new ArgumentNullException(nameof(connectionHelper));
             _tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
             _inputQueueName = inputQueueName;
@@ -127,14 +130,14 @@ namespace Rebus.Oracle.Transport
                         :headers,
                         :body,
                         :priority,
-                        systimestamp(6) + :visible,
-                        systimestamp(6) + :ttlseconds
+                        :now + :visible,
+                        :now + :ttlseconds
                     )";
 
                 var headers = message.Headers.Clone();
 
                 var priority = GetMessagePriority(headers);
-                var initialVisibilityDelay = new TimeSpan(0, 0, 0, GetInitialVisibilityDelay(headers));
+                var initialVisibilityDelay = new TimeSpan(0, 0, 0, GetInitialVisibilityDelay(headers, _rebusTime.Now));
                 var ttlSeconds = new TimeSpan(0, 0, 0, GetTtlSeconds(headers));
 
                 // must be last because the other functions on the headers might change them
@@ -144,6 +147,7 @@ namespace Rebus.Oracle.Transport
                 command.Parameters.Add(new OracleParameter("headers", OracleDbType.Blob, serializedHeaders, ParameterDirection.Input));
                 command.Parameters.Add(new OracleParameter("body", OracleDbType.Blob, message.Body, ParameterDirection.Input));
                 command.Parameters.Add(new OracleParameter("priority", OracleDbType.Int64, priority, ParameterDirection.Input));
+                command.Parameters.Add(new OracleParameter("now", OracleDbType.TimeStampTZ, _rebusTime.Now.ToUniversalTime().DateTime, ParameterDirection.Input));
                 command.Parameters.Add(new OracleParameter("visible", OracleDbType.IntervalDS, initialVisibilityDelay, ParameterDirection.Input));
                 command.Parameters.Add(new OracleParameter("ttlseconds", OracleDbType.IntervalDS, ttlSeconds, ParameterDirection.Input));
 
@@ -165,6 +169,7 @@ namespace Rebus.Oracle.Transport
                     selectCommand.CommandText = $"rebus_dequeue_{_tableName}";
                     selectCommand.CommandType = CommandType.StoredProcedure;
                     selectCommand.Parameters.Add(new OracleParameter("recipientQueue", OracleDbType.VarChar, _inputQueueName, ParameterDirection.Input));
+                    selectCommand.Parameters.Add(new OracleParameter("now", OracleDbType.TimeStampTZ, _rebusTime.Now.ToUniversalTime().DateTime, ParameterDirection.Input));
                     selectCommand.Parameters.Add(new OracleParameter("output", OracleDbType.Cursor ,ParameterDirection.Output));
                     selectCommand.InitialLobFetchSize = -1;
 
@@ -212,9 +217,10 @@ namespace Rebus.Oracle.Transport
                             $@"
                             delete from {_tableName} 
                             where recipient = :recipient 
-                            and expiration < systimestamp(6)
+                            and expiration < :now
                             ";
                         command.Parameters.Add(new OracleParameter("recipient", OracleDbType.VarChar, _inputQueueName, ParameterDirection.Input));
+                        command.Parameters.Add(new OracleParameter("now", OracleDbType.TimeStampTZ, _rebusTime.Now.ToUniversalTime().DateTime, ParameterDirection.Input));
                         affectedRows = await command.ExecuteNonQueryAsync();
                     }
 
@@ -273,8 +279,8 @@ CREATE TABLE {_tableName}
     id NUMBER(20) NOT NULL,
     recipient VARCHAR2(255) NOT NULL,
     priority NUMBER(20) NOT NULL,
-    expiration timestamp(7) with time zone NOT NULL,
-    visible timestamp(7) with time zone NOT NULL,
+    expiration timestamp with time zone NOT NULL,
+    visible timestamp with time zone NOT NULL,
     headers blob NOT NULL,
     body blob NOT NULL
 )
@@ -299,7 +305,7 @@ CREATE INDEX idx_receive_{_tableName} ON {_tableName}
     visible ASC
 )
 ----
-create or replace PROCEDURE rebus_dequeue_{_tableName}(recipientQueue IN varchar, output OUT SYS_REFCURSOR ) AS
+create or replace PROCEDURE rebus_dequeue_{_tableName}(recipientQueue IN varchar, now IN timestamp with time zone, output OUT SYS_REFCURSOR ) AS
   messageId number;
   readCursor SYS_REFCURSOR; 
 begin
@@ -308,9 +314,9 @@ begin
     SELECT id
     FROM {_tableName}
     WHERE recipient = recipientQueue
-            and visible < current_timestamp(6)
-            and expiration > current_timestamp(6)          
-    ORDER BY priority ASC, id ASC
+            and visible < now
+            and expiration > now         
+    ORDER BY priority ASC, visible ASC, id ASC
     for update skip locked;
     
     fetch readCursor into messageId;
@@ -419,7 +425,7 @@ END;
             }
         }
 
-        static int GetInitialVisibilityDelay(IDictionary<string, string> headers)
+        static int GetInitialVisibilityDelay(IDictionary<string, string> headers, DateTimeOffset now)
         {
             if (!headers.TryGetValue(Headers.DeferredUntil, out var deferredUntilDateTimeOffsetString))
             {
@@ -430,7 +436,7 @@ END;
 
             headers.Remove(Headers.DeferredUntil);
 
-            return (int)(deferredUntilTime - RebusTime.Now).TotalSeconds;
+            return (int)(deferredUntilTime - now).TotalSeconds;
         }
 
         static int GetTtlSeconds(IReadOnlyDictionary<string, string> headers)

--- a/Rebus.Oracle.Devart/Rebus.Oracle.Devart.csproj
+++ b/Rebus.Oracle.Devart/Rebus.Oracle.Devart.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Devart.Data.Oracle" Version="9.5.454" />
-    <PackageReference Include="Rebus" Version="4.2.1" />
+    <PackageReference Include="Rebus" Version="6.0.0-b11" />
   </ItemGroup>
 
 </Project>

--- a/Rebus.Oracle.Tests/Integration/TestOracleAllTheWay.cs
+++ b/Rebus.Oracle.Tests/Integration/TestOracleAllTheWay.cs
@@ -28,6 +28,7 @@ namespace Rebus.Oracle.Tests.Integration
 
             _bus = Configure.With(_activator)
                 .Transport(x => x.UseOracle(ConnectionString, "transports", "test.input", true))
+                .Subscriptions(_ => _.StoreInOracle(ConnectionString, "subscriptions", true, enlistInAmbientTransaction: true))
                 .Options(x =>
                 {
                     x.SetNumberOfWorkers(1);
@@ -39,6 +40,7 @@ namespace Rebus.Oracle.Tests.Integration
         protected override void TearDown()
         {
             OracleTestHelper.DropTableAndSequence("transports");
+            OracleTestHelper.DropTableAndSequence("subscriptions");
             OracleTestHelper.DropProcedure("rebus_dequeue_transports");
         }
 
@@ -90,6 +92,84 @@ namespace Rebus.Oracle.Tests.Integration
                 }, TransactionScopeAsyncFlowOption.Enabled))
                 {
                     await _bus.SendLocal("alles cavakes?");
+
+                    if (throwInsideTransactionScope)
+                    {
+                        throw new RebusApplicationException("the ting goes skraa");
+                    }
+
+                    if (completeTransaction)
+                    {
+                        tx.Complete();
+                    }
+                }
+            }
+            catch (RebusApplicationException) when (throwInsideTransactionScope)
+            {
+                // Intended
+            }
+
+            if (expectMessageReceived)
+            {
+                gotTheMessage.WaitOrDie(TimeSpan.FromSeconds(10));
+            }
+
+            await Task.Delay(500);
+
+            Assert.That(receivedMessageCount, Is.EqualTo(expectMessageReceived ? 1 : 0));
+        }
+
+        [Test]
+        public async Task PublishAndReceivesOneSingleMessage()
+        {
+            await _bus.Subscribe<string>();
+
+            var gotTheMessage = new ManualResetEvent(false);
+            var receivedMessageCount = 0;
+
+            _activator.Handle<string>(async message =>
+            {
+                await Task.CompletedTask;
+                Interlocked.Increment(ref receivedMessageCount);
+                Console.WriteLine("Received message: {0}", message);
+                gotTheMessage.Set();
+            });
+
+            await _bus.Publish("hallo daar mijn vriend!");
+
+            gotTheMessage.WaitOrDie(TimeSpan.FromSeconds(10));
+
+            await Task.Delay(500);
+
+            Assert.That(receivedMessageCount, Is.EqualTo(1));
+        }
+
+        [TestCase(true, false, true)]
+        [TestCase(false, false, false)]
+        [TestCase(true, true, false)]
+        public async Task PublishAndReceiveOneSingleMessageInAnAmbientTransaction(bool completeTransaction, bool throwInsideTransactionScope, bool expectMessageReceived)
+        {
+            await _bus.Subscribe<string>();
+            var gotTheMessage = new ManualResetEvent(false);
+            var receivedMessageCount = 0;
+
+            _activator.Handle<string>(async message =>
+            {
+                await Task.CompletedTask;
+                Interlocked.Increment(ref receivedMessageCount);
+                Console.WriteLine("Received message: {0}", message);
+                gotTheMessage.Set();
+            });
+
+            try
+            {
+                using (var tx = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions
+                {
+                    IsolationLevel = IsolationLevel.ReadCommitted,
+                    Timeout = TimeSpan.FromSeconds(60)
+                }, TransactionScopeAsyncFlowOption.Enabled))
+                {
+                    await _bus.Publish("alles cavakes?");
 
                     if (throwInsideTransactionScope)
                     {


### PR DESCRIPTION
Copied changes #17, #20 and #22 from Rebus.Oracle to Rebus.Oracle.Devart.

This means we have a breaking change for users of the Devart provider as well, see the discussion [here.](https://github.com/rebus-org/Rebus.Oracle/pull/20#issuecomment-522162515)